### PR TITLE
Added API rule for non-existing parameters

### DIFF
--- a/The Design Rules v1.0.md
+++ b/The Design Rules v1.0.md
@@ -209,7 +209,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
   <p class="rulelab"><strong>API-XX</strong>: Handle invalid or illegal parameters</p>
   <p>The HTTP specification [[rfc7231]] specifies that a code 400 (bad request) must be sent as response to *something that is perceived to be a client error*. Furthermore, the
   [[OGC API-Features specification]](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0) states that *the server shall respond with a status code 400 if the request URI includes a query parameter that is not specified in the definition* (Requirement 8)</p>
-  <p>A client requesting information using a non-existing parameter will assume that the response is filtered using that parameter. For example, when a user user a non-existing parameter-value pair like *colour=red* the user will assume that only objects are returned with that colour. When a service ignores non-existing parameters it will return *all* objects, regardless of their colour.</>
+  <p>A client requesting information using a non-existing parameter will assume that the response is filtered using that parameter. For example, when a user applies a non-existing parameter-value pair like `colour=red` the user will assume that only objects are returned with that colour. When a service ignores non-existing parameters it will return *all* objects, regardless of their colour.</>
   <p>The server shall return the 400 code as specified in the HTTP specification [[rfc7231]] and the [[OGC API-Features specification]](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0) Requirement 8.
   </p>
 </div>

--- a/The Design Rules v1.0.md
+++ b/The Design Rules v1.0.md
@@ -205,6 +205,14 @@ Although the REST architectural style does not impose a specific protocol, REST 
   </table>
 </div>
 
+<div class="rule" id="api-XX">
+  <p class="rulelab"><strong>API-XX</strong>: Handle invalid or illegal parameters</p>
+  <p>The HTTP specification [[rfc7231]] specifies that a code 400 (bad request) must be sent as response to *something that is perceived to be a client error*. This applies to API requests for non-existing parameters too. A client requesting information using a non-existing parameter will assume that the response is filtered using that parameter.</p>
+  <p>For example, when a user user a non-existing parameter-value pair like *colour=red* the user will assume that only objects are returned with that colour. When a service ignores non-existing parameters it will return *all* objects, regardless of their colour.</>
+  <p>The server must return the 400 code as specified in the HTTP specification [[rfc7231]].
+  </p>
+</div>
+
 ## Statelessness
 
 One of the key constraints of the REST architectural style is stateless communication between client and server. It means that every request from client to server must contain all of the information necessary to understand the request. The server cannot take advantage of any stored session context on the server as it didn’t memorize previous requests. Session state must therefore reside entirely on the client.

--- a/The Design Rules v1.0.md
+++ b/The Design Rules v1.0.md
@@ -207,9 +207,10 @@ Although the REST architectural style does not impose a specific protocol, REST 
 
 <div class="rule" id="api-XX">
   <p class="rulelab"><strong>API-XX</strong>: Handle invalid or illegal parameters</p>
-  <p>The HTTP specification [[rfc7231]] specifies that a code 400 (bad request) must be sent as response to *something that is perceived to be a client error*. This applies to API requests for non-existing parameters too. A client requesting information using a non-existing parameter will assume that the response is filtered using that parameter.</p>
-  <p>For example, when a user user a non-existing parameter-value pair like *colour=red* the user will assume that only objects are returned with that colour. When a service ignores non-existing parameters it will return *all* objects, regardless of their colour.</>
-  <p>The server must return the 400 code as specified in the HTTP specification [[rfc7231]].
+  <p>The HTTP specification [[rfc7231]] specifies that a code 400 (bad request) must be sent as response to *something that is perceived to be a client error*. Furthermore, the
+  [[OGC API-Features specification]](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0) states that *the server shall respond with a status code 400 if the request URI includes a query parameter that is not specified in the definition* (Requirement 8)</p>
+  <p>A client requesting information using a non-existing parameter will assume that the response is filtered using that parameter. For example, when a user user a non-existing parameter-value pair like *colour=red* the user will assume that only objects are returned with that colour. When a service ignores non-existing parameters it will return *all* objects, regardless of their colour.</>
+  <p>The server shall return the 400 code as specified in the HTTP specification [[rfc7231]] and the [[OGC API-Features specification]](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0) Requirement 8.
   </p>
 </div>
 


### PR DESCRIPTION
For discussion by the working group. The response to an invalid or non-existing parameter must be a 400 code according to the HTTP specification.