### PR TITLE
[API-56] Clarify use of pre-release versions

### DIFF
--- a/DesignRules.md
+++ b/DesignRules.md
@@ -623,7 +623,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Rationale</dt>
       <dd>
-         Version numbering must follow the Semantic Versioning [[SemVer]] model to prevent breaking changes when releasing new API versions. Versions are formatted using the <code>major.minor.patch</code> template. When releasing a new version which contains backwards-incompatible changes, a new major version must be released. Minor and patch releases may only contain backwards compatible changes (e.g. the addition of an endpoint or an optional attribute).
+         Version numbering must follow the Semantic Versioning [[SemVer]] model to prevent breaking changes when releasing new API versions. Release versions are formatted using the <code>major.minor.patch</code> template (examples: 1.0.2, 1.11.0). Pre-release versions may be denoted by appending a hyphen and a series of dot separated identifiers (examples: 1.0.2-rc.1, 2.0.0-beta.3). When releasing a new version which contains backwards-incompatible changes, a new major version must be released. Minor and patch releases may only contain backwards compatible changes (e.g. the addition of an endpoint or an optional attribute).
       </dd>
       <dt>Implications</dt>
       <dd>


### PR DESCRIPTION
As suggested in https://github.com/Geonovum/KP-APIs/issues/529, design rule API-56 should explain how to deal with pre-release versions. This PR aligns the design rule with [the relevant part of the SemVer standard](https://semver.org/#spec-item-9). 