### PR TITLE
Adr validator links bijgewerkt

### DIFF
--- a/DesignRules.md
+++ b/DesignRules.md
@@ -117,7 +117,7 @@ A resource describing a single thing is called a [singular resource](#dfn-singul
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -209,7 +209,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -455,7 +455,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -507,7 +507,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -582,7 +582,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -627,7 +627,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -654,7 +654,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/main/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -117,7 +117,7 @@ A resource describing a single thing is called a [singular resource](#dfn-singul
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_48.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -209,7 +209,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_03.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -455,7 +455,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_16.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -507,7 +507,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_51.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -582,7 +582,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_20.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -627,7 +627,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_56.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -654,7 +654,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code can be found <a href="https://github.com/VNG-Realisatie/api-test-platform-code/blob/master/src/vng/design_rules/tasks/dr_20200709/api_57.py">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
       </dd>
       <dt>Rule types</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -117,7 +117,7 @@ A resource describing a single thing is called a [singular resource](#dfn-singul
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -209,7 +209,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -455,7 +455,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -507,7 +507,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -582,7 +582,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -627,7 +627,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -654,7 +654,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -117,7 +117,7 @@ A resource describing a single thing is called a [singular resource](#dfn-singul
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -209,7 +209,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -455,7 +455,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -507,7 +507,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -582,7 +582,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -627,7 +627,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>
@@ -654,7 +654,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go">here</a>. The specific tests are publisched in the [[ADR-Validator]] repository.
       </dd>
       <dt>Rule types</dt>
       <dd>

--- a/Summary.md
+++ b/Summary.md
@@ -6,24 +6,31 @@ Design rules have unique and permanent numbers. In the event of design rules bei
 
 ### Normative Design Rules
 
-Design rules can be technical rules, which should be tested automatically and functional rules which should be considerd when designing and building the api. 
+Design rules can be technical rules, which should be tested automatically and functional rules which should be considerd when designing and building the api.
 
-* <a href="#api-01">API-01</a>: Adhere to HTTP safety and idempotency semantics for operations - *Functional rule*
-* <a href="#api-02">API-02</a>: Do not maintain session state on the server - *Functional rule*
-* <a href="#api-03">API-03</a>: Only apply standard HTTP methods - *Technical rule*
-* <a href="#api-04">API-04</a>: Define interfaces in Dutch unless there is an official English glossary available - *Functional rule*
-* <a href="#api-05">API-05</a>: Use nouns to name resources - *Functional rule*
-* <a href="#api-06">API-06</a>: Use nested URIs for child resources - *Functional rule*
-* <a href="#api-10">API-10</a>: Model resource operations as a sub-resource or dedicated resource - *Functional rule*
-* <a href="#api-16">API-16</a>: Use OpenAPI Specification for documentation - *Technical rule*
-* <a href="#api-17">API-17</a>: Publish documentation in Dutch unless there is existing documentation in English - *Functional rule*
-* <a href="#api-18">API-18</a>: Include a deprecation schedule when publishing API changes - *Functional rule*
-* <a href="#api-19">API-19</a>: Schedule a fixed transition period for a new major API version - *Functional rule*
-* <a href="#api-20">API-20</a>: Include the major version number in the URI - *Technical rule*
-* <a href="#api-48">API-48</a>: Leave off trailing slashes from URIs - *Technical rule*
-* <a href="#api-51">API-51</a>: Publish OAS document at a standard location in JSON-format - *Technical rule*
-* <a href="#api-53">API-53</a>: Hide irrelevant implementation details - *Functional rule*
-* <a href="#api-54">API-54</a>: Use plural nouns to name collection resources - *Functional rule*
-* <a href="#api-55">API-55</a>: Publish a changelog for API changes between versions - *Functional rule*
-* <a href="#api-56">API-56</a>: Adhere to the Semantic Versioning model when releasing API changes - *Technical rule*
-* <a href="#api-57">API-57</a>: Return the full version number in a response header - *Technical rule*
+#### List of functional rules
+
+* <a href="#api-01">API-01</a>: Adhere to HTTP safety and idempotency semantics for operations.
+* <a href="#api-02">API-02</a>: Do not maintain session state on the server.
+* <a href="#api-04">API-04</a>: Define interfaces in Dutch unless there is an official English glossary available.
+* <a href="#api-05">API-05</a>: Use nouns to name resources.
+* <a href="#api-06">API-06</a>: Use nested URIs for child resources.
+* <a href="#api-10">API-10</a>: Model resource operations as a sub-resource or dedicated resource.
+* <a href="#api-17">API-17</a>: Publish documentation in Dutch unless there is existing documentation in English.
+* <a href="#api-18">API-18</a>: Include a deprecation schedule when publishing API changes.
+* <a href="#api-19">API-19</a>: Schedule a fixed transition period for a new major API version.
+* <a href="#api-53">API-53</a>: Hide irrelevant implementation details.
+* <a href="#api-54">API-54</a>: Use plural nouns to name collection resources.
+* <a href="#api-55">API-55</a>: Publish a changelog for API changes between versions.
+
+#### List of technical rules
+
+* <a href="#api-03">API-03</a>: Only apply standard HTTP methods.
+* <a href="#api-16">API-16</a>: Use OpenAPI Specification for documentation.
+* <a href="#api-20">API-20</a>: Include the major version number in the URI.
+* <a href="#api-48">API-48</a>: Leave off trailing slashes from URIs.
+* <a href="#api-51">API-51</a>: Publish OAS document at a standard location in JSON-format.
+* <a href="#api-56">API-56</a>: Adhere to the Semantic Versioning model when releasing API changes.
+* <a href="#api-57">API-57</a>: Return the full version number in a response header.
+
+

--- a/js/config.js
+++ b/js/config.js
@@ -121,6 +121,13 @@ var respecConfig =
       title: "Semantic Versioning 2.0.0",
       authors: ["T. Preston-Werner"],
       date: "June 2013"
-    }
+    },
+    "ADR-Validator": {
+      href: "https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go",
+      title: "Technical ADR Validation rule testset 0.1.0",
+      authors: ["H. Stijns"],
+      publisher: "Geonovum",
+      date: "December 2022"
+    },
   },
 };

--- a/js/config.js
+++ b/js/config.js
@@ -1,133 +1,47 @@
-//-------------------------------------------------------------------------------------
-//-- File. . . :  config.js
-//-- Bevat . . :  Template voor de  configuratie voor respec
-//--              Gebaseerd op https://github.com/Geonovum/respec/wiki
-//--              Deze file moet worden neergezet in de root-directory van de
-//--              betreffende standaard.
-//-- Door. . . :  Frank Terpstra/Jan van Gelder
-//-------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------
-//-- Log . . . :  20180615 - FT  - Initiele versie
-//-- . . . . . :  20181106 - JvG - verplaatst naar root KP-APIs
-//-- . . . . . :  20220125 - MvdP - Nieuwe versie / opzet in lijn met de modulaire opbouw
-//-------------------------------------------------------------------------------------
-
-var respecConfig =
-{
-  specStatus: "WV",
-  specType: "ST",
-  pubDomain: "api",
-  shortName: "adr",
-  publishDate: "2022-01-25",
-  publishVersion: "1.1",
-  // previousPublishVersion: "(none)",
-
-  // postProcess: [repair],
-  //  previousPublishDate: "2019-07-15",
-  //  previousMaturity: "GN-VV",
-  editors:
-    [
-      {
-        name: "Frank Terpstra",
-        company: "Geonovum",
-        companyURL: "https://www.geonovum.nl",
+var respecConfig = {
+  alternateFormats: [ { 
+        "label" : "pdf",
+        "uri" : "API-Design-Rules.pdf"
+      } ],
+  authors: [ 
+      { 
+        "company" : "Het Kadaster",
+        "companyURL" : "https://www.kadaster.nl",
+        "name" : "Jasper Roes"
       },
-      {
-        name: "Jan van Gelder",
-        company: "Geonovum",
-        companyURL: "https://www.geonovum.nl",
-      },
-      {
-        name: "Alexander Green",
-        company: "Logius",
-        companyURL: "https://www.logius.nl",
-      },
-      {
-        name: "Martin van der Plas",
-        company: "Logius",
-        companyURL: "https://www.logius.nl",
+      { 
+        "company" : "Het Kadaster",
+        "companyURL" : "https://www.kadaster.nl",
+        "name" : "Joost Farla"
       }
     ],
-  authors:
-    [
-      {
-        name: "Jasper Roes",
-        company: "Het Kadaster",
-        companyURL: "https://www.kadaster.nl",
+  editors: [ 
+      { 
+        "company" : "Geonovum",
+        "companyURL" : "https://www.geonovum.nl",
+        "name" : "Frank Terpstra"
       },
-      {
-        name: "Joost Farla",
-        company: "Het Kadaster",
-        companyURL: "https://www.kadaster.nl",
+      { 
+        "company" : "Geonovum",
+        "companyURL" : "https://www.geonovum.nl",
+        "name" : "Jan van Gelder"
+      },
+      { 
+        "company" : "Logius",
+        "companyURL" : "https://www.logius.nl",
+        "name" : "Alexander Green"
+      },
+      { 
+        "company" : "Logius",
+        "companyURL" : "https://www.logius.nl",
+        "name" : "Martin van der Plas"
       }
     ],
   github: "https://github.com/Logius-standaarden/API-Design-Rules",
-  nl_github: {
-    issueBase: "https://github.com/Geonovum/KP-APIs/issues",
-    revision: "https://github.com/Logius-standaarden/API-Design-Rules/commits",
-    pullsBase: "https://github.com/Geonovum/KP-APIs/pulls",
-  },
- // Controls if linked "§" section markers are added to a document
- addSectionLinks: true,
- 
-    // this parameter will add the tag_name of the latest release to the document Title
-  // only set this parameter when a release has been set
-  nl_addReleaseTagTitle: true,
-
-    // nl_organisationName is used for some company specific values in the header (and Sotd)
-  // currently supported: Logius and Geonovum (default)  
-  nl_organisationName: "Logius",
-
-  // prefix for the names of company specific css, svg and ico prefixes
-  // defaults to "GN-"  
-  nl_organisationPrefix: "LS-",
-
-  // class style can be automatically insertd in generated markdown tables
-  // currently defaults to simple, but this may change    
-  //  nl_markdownTableClass: "ebms",
-
-  // if nl_markdownEmbedImageInFigure is set to true images in markdown generated content will be surrounded with <figures> element
-  // so that figures can be linked are be a part of table of figures
-  nl_markdownEmbedImageInFigure: true,
-
-  // this url points to the folder where organsation specific css files are stored
-  // defaults to https://tools.geostandaarden.nl/respec/style/ if not set
-  nl_organisationStylesURL: "https://publicatie.centrumvoorstandaarden.nl/respec/style/",
-
-  // nl_organisationPublishURL points to organisation specifica publication page, used in header
-  // defaults to  https://docs.geostandaarden.nl/"
-  nl_organisationPublishURL: "https://publicatie.centrumvoorstandaarden.nl/",
-
-  // nl_logo refers to company logo
-  // defaults to https://tools.geostandaarden.nl/respec/style/logos/Geonovum.svg
-  nl_logo: {
-    src: "https://publicatie.centrumvoorstandaarden.nl/respec/style/logos/figure-logius.svg",
-    alt: "Logius",
-    id: "Logius",
-    height: 77,
-    width: 44,
-    url: "https://www.logius.nl/standaarden",
-  },
-  alternateFormats: [
-    {
-      label: "pdf",
-      uri: "API-Design-Rules.pdf",
-    },
-    ],
-
-  localBiblio: {
-    "SemVer": {
-      href: "https://semver.org",
-      title: "Semantic Versioning 2.0.0",
-      authors: ["T. Preston-Werner"],
-      date: "June 2013"
-    },
-    "ADR-Validator": {
-      href: "https://gitlab.com/commonground/don/adr-validator/-/blob/v0.1.0/pkg/adr/rules.go",
-      title: "Technical ADR Validation rule testset 0.1.0",
-      authors: ["H. Stijns"],
-      publisher: "Geonovum",
-      date: "December 2022"
-    },
-  },
+  pubDomain: "api",
+  publishDate: "2022-01-25",
+  publishVersion: "1.1",
+  shortName: "adr",
+  specStatus: "WV",
+  specType: "ST"
 };


### PR DESCRIPTION
Ik heb de links bijgewerkt naar de actuele testcases die nu operationeel zijn in Developer.overheid.nl
verder is ook de lijst van design rules gesplitst in 1 lijst functionele rules (niet testbaar) en 1 lijst technische rules (wel testbaar). ook de local biblio bijgewerkt met een referentie naar de ADR validator testset.
 