### PR TITLE
Mrtn78 patch verduidelijken inleiding

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -18,7 +18,7 @@ Despite the fact that two authors are mentioned in the list of authors, this doc
 
 This document is part of the *Nederlandse API Strategie*.
 
-The Nederlandse API Strategie consists of [three distinct documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
+The Nederlandse API Strategie consists of [three layers of distinct documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
 
 | Part | Description                                  | Status      | Link                                                  |
 | :--- | :------------------------------------------- | :---------- | :---------------------------------------------------- |
@@ -27,6 +27,10 @@ The Nederlandse API Strategie consists of [three distinct documents](https://www
 | IIb  | Extension on the Standard for designing APIs | Informative | https://docs.geostandaarden.nl/api/API-Strategie-ext/ |
 
 Before reading this document it's adviced to gain knowledge of the three documents and more specific [the architecture section of part I](https://docs.geostandaarden.nl/api/API-Strategie/#architectuur).
+
+An actual overview of all current documents is available in this dutch infographic:
+![NL API Strategie Infographic](https://raw.githubusercontent.com/Geonovum/KP-APIs/a0ee2f718777eb333a4e625edb1e8ce1387b51d3/media/API_infographic.svg)
+
 
 ## Extensions
 <aside class="note">

--- a/Introduction.md
+++ b/Introduction.md
@@ -20,11 +20,15 @@ This document is part of the *Nederlandse API Strategie*.
 
 The Nederlandse API Strategie consists of [three distinct documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
 
+| Part | Description                                  | Status      | Link                                                  |
+| :--- | :------------------------------------------- | :---------- | :---------------------------------------------------- |
+| I    | General description of the API Strategy      | Informative | https://docs.geostandaarden.nl/api/API-Strategie/     |
+| IIa  | Standard for designing APIs                  | Normative   | https://publicatie.centrumvoorstandaarden.nl/api/adr/ |
+| IIb  | Extension on the Standard for designing APIs | Informative | https://docs.geostandaarden.nl/api/API-Strategie-ext/ |
+
+Before reading this document it's adviced to gain knowledge of the three documents and more specific [the architecture section of part I](https://docs.geostandaarden.nl/api/API-Strategie/#architectuur).
+
 ## Extensions
-
-In addition to this (normative) document, a separate document has been written providing a set of informative extensions. This extensions document exists in a *latest published version* (*Gepubliceerde versie* in Dutch) and a *latest editors draft* (*Werkversie* in Dutch). The *latest editor's draft*s is actively being worked on and can be found on GitHub. It contains the most recent changes.
-
-The documents can be found here:
-
-* [Extensions Gepubliceerde versie](https://docs.geostandaarden.nl/api/API-Strategie-ext/)  
-* [Extensions Werkversie](https://geonovum.github.io/KP-APIs/API-strategie-extensies/)
+<aside class="note">
+In addition to this (normative) document, separate modules are being written to provide a set of extensions. These modules are all separate documents and exists in a [latest editors draft](https://geonovum.github.io/KP-APIs/) (Werkversie in Dutch). The latest editor's draft is actively being worked on and can be found on [GitHub](https://github.com/Geonovum/KP-APIs). It contains the most recent changes.
+</aside>

--- a/Introduction.md
+++ b/Introduction.md
@@ -34,5 +34,5 @@ An actual overview of all current documents is available in this Dutch infograph
 
 ## Extensions
 <aside class="note">
-In addition to this (normative) document, separate modules are being written to provide a set of extensions. These modules are all separate documents and exists in a <a href="https://geonovum.github.io/KP-APIs/">latest editors draft</a> (<i>Werkversie</i> in Dutch). The latest editor&#39;s draft is actively being worked on and can be found on <a href="https://github.com/Geonovum/KP-APIs">GitHub</a>. It contains the most recent changes.
+In addition to this (normative) document, separate modules are being written to provide a set of extensions. These modules are all separate documents and exists in a <a href="https://geonovum.github.io/KP-APIs/">latest editor's draft</a> (<i>Werkversie</i> in Dutch). The latest editor's draft is actively being worked on and can be found on <a href="https://github.com/Geonovum/KP-APIs">GitHub</a>. It contains the most recent changes.
 </aside>

--- a/Introduction.md
+++ b/Introduction.md
@@ -26,13 +26,13 @@ The Nederlandse API Strategie consists of [three layers of distinct documents](h
 | IIa  | Standard for designing APIs                  | Normative   | https://publicatie.centrumvoorstandaarden.nl/api/adr/ |
 | IIb  | Extension on the Standard for designing APIs | Informative | https://docs.geostandaarden.nl/api/API-Strategie-ext/ |
 
-Before reading this document it's adviced to gain knowledge of the three documents and more specific [the architecture section of part I](https://docs.geostandaarden.nl/api/API-Strategie/#architectuur).
+Before reading this document it is advised to gain knowledge of the three documents, in particular [the architecture section of part I](https://docs.geostandaarden.nl/api/API-Strategie/#architectuur).
 
-An actual overview of all current documents is available in this dutch infographic:
+An actual overview of all current documents is available in this Dutch infographic:
 ![NL API Strategie Infographic](https://raw.githubusercontent.com/Geonovum/KP-APIs/a0ee2f718777eb333a4e625edb1e8ce1387b51d3/media/API_infographic.svg)
 
 
 ## Extensions
 <aside class="note">
-In addition to this (normative) document, separate modules are being written to provide a set of extensions. These modules are all separate documents and exists in a [latest editors draft](https://geonovum.github.io/KP-APIs/) (Werkversie in Dutch). The latest editor's draft is actively being worked on and can be found on [GitHub](https://github.com/Geonovum/KP-APIs). It contains the most recent changes.
+In addition to this (normative) document, separate modules are being written to provide a set of extensions. These modules are all separate documents and exists in a <a href="https://geonovum.github.io/KP-APIs/">latest editors draft</a> (<i>Werkversie</i> in Dutch). The latest editor&#39;s draft is actively being worked on and can be found on <a href="https://github.com/Geonovum/KP-APIs">GitHub</a>. It contains the most recent changes.
 </aside>


### PR DESCRIPTION
Ik heb kleine verbeteringen in de inleiding doorgevoerd en de verwijzing opgenomen naar de infographic. Aangezien dit document in engels is en de formele inleiding van de NL API Strategie in het nederlands heb ik besloten het beknopt te houden en niet de hele inleiding van de strategie weer integraal over te nemen in de Normatieve design rules.

Reading guide geupdate op basis van https://github.com/Geonovum/KP-APIs/issues/132
This change replaces commit: https://github.com/Logius-standaarden/API-Design-Rules/commit/76524fe802f1ac17dd0c672f1bd4a8d9b9a1799c
