### PR TITLE
Patch how to test

### DIFF
--- a/DesignRules.md
+++ b/DesignRules.md
@@ -105,15 +105,10 @@ A resource describing a single thing is called a [=singular resource=]. Resource
       <dt>Implications</dt>
       <dd>
          This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
-      </dd>      
+      </dd>
       <dt>How to test</dt>
       <dd>
-         <ul>
-            <li> Step 1: The API MUST meet the prerequisets to be tested. These include that an OAS file is publicly available, parsable, all $refs are resolvable and paths are defined.</li>
-            <li> Step 2: Check if paths are present in the OpenAPI Specification.</li>
-            <li> Step 3: Loop all paths and check if it ends with a forward slash (<code>/</code>).</li>
-            <li> Step 4: Check all paths with a get request and without parameters. They SHOULD resolve in HTTP 404.</li>
-         </ul>
+         Loop all resource paths in the OpenAPI Specification and check that no resources paths end with a forward slash (<code>/</code>).
       </dd>
    </dl>
 </div>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -244,27 +244,9 @@ Although the REST architectural style does not impose a specific protocol, REST 
   In addition to the standard HTTP methods, a server may support other optional methods as well, e.g. <code>PROPFIND</code>, <code>COPY</code>, <code>PURGE</code>, <code>VIEW</code>, <code>LINK</code>, <code>UNLINK</code>, <code>LOCK</code>, <code>UNLOCK</code>, etc.<br>
   If an optional HTTP request method is sent to a server and the server does not support that HTTP method for the target resource, an HTTP status code <code>405 Method Not Allowed</code> shall be returned and a list of allowed methods for the target resource shall be provided in the <code>Allow</code> header in the response as stated in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5">RFC 7231 6.5.5</a>.</p>
       <dt>How to test</dt>
-      <p>Test case 1:</p>
       <dd>
-         <ul>
-            <li> Step 1: The API MUST meet the prerequisites to be tested. These include that an OAS file is publicly available, parsable, all $refs are resolvable and paths are defined.</li>
-            <li> Step 2: Send an HTTP GET or HEAD request to any of the endpoints with a definition of a GET operation mentioned in the OAS file. The server MUST respond with a HTTP status code other than <code>405 Method Not Allowed</code>.</li>
-        </ul>
+         The open api specification MUST NOT include non standard HTTP methods for retrieving or manipulating resources.
       </dd>
-      <p>Test case 2:</p>
-      <dd>
-         <ul>
-            <li> Step 1: The API MUST meet the prerequisites to be tested. These include that an OAS file is publicly available, parsable, all $refs are resolvable, and paths are defined.</li>
-            <li> Step 2: Send a request to the API with an optional HTTP method that is supported by the API. The server MUST respond with an HTTP status code other than <code>405 Method Not Allowed</code>.</li>
-      </ul>
-      </dd>
-     <p>Test case 3:</p>
-      <dd>
-         <ul>
-            <li> Step 1: The API MUST meet the prerequisites to be tested. These include that an OAS file is publicly available, parsable, all $refs are resolvable, and paths are defined.</li>
-            <li> Step 2: Send a request to the API with an optional HTTP method that is not supported by the API. The server MUST respond with an HTTP status code <code>405 Method Not Allowed</code>. The response MUST contain an <code>Allow</code> header with a list of supported methods for the target resource.</li>
-      </ul>
-      </dd>   
    </dl>
 </div>
 

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -108,7 +108,7 @@ A resource describing a single thing is called a [=singular resource=]. Resource
       </dd>
       <dt>How to test</dt>
       <dd>
-         Loop all resource paths in the OpenAPI Specification and check that no resources paths end with a forward slash (<code>/</code>).
+         Loop all resource paths in the OpenAPI Description and check that no resources paths end with a forward slash (<code>/</code>).
       </dd>
    </dl>
 </div>
@@ -480,7 +480,7 @@ An API is as good as the accompanying documentation. The documentation has to be
          <ul>
             <li> Step 1: The API MUST meet the prerequisets to be tested. These include that an OAS file (openapi.json) is publicly available, parsable, all $refs are resolvable and paths are defined.</li>
             <li> Step 2: The openapi.yaml MAY be available. If available it MUST contain yaml, be readable and parsable.</li>
-            <li> Step 3: The openapi.yaml MUST contain the same OpenAPI Specification as the openapi.json.</li>
+            <li> Step 3: The openapi.yaml MUST contain the same OpenAPI Description as the openapi.json.</li>
             <li> Step 4: The CORS header Access-Control-Allow-Origin MUST allow all origins.</li>
          </ul>
       </dd>
@@ -556,7 +556,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       <dd>
          <ul>
             <li> Step 1: The base path MUST contain a version number.</li>
-            <li> Step 2: Each url of the server object of the OpenAPI Specification MUST include a version number.</li>
+            <li> Step 2: Each url of the server object of the OpenAPI Description MUST include a version number.</li>
             <li> Step 3: The version in the OAS file MUST be the same as the version in the base path.</li>
          </ul>
       </dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -621,12 +621,8 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>How to test</dt>
       <dd>
-         <ul>
-            <li> Step 1: The API MUST meet the prerequisets to be tested. These include that an OAS file (openapi.json) is publicly available, parsable, all $refs are resolvable and paths are defined.</li>
-            <li> Step 2: In the open api specification the info and version object MUST be available.</li>
-            <li> Step 3: The version MUST comply with Semantic Versioning.</li>
-         </ul>
-      </dd> 
+         The "API-Version" response header MUST comply with Semantic Versioning.
+      </dd>
    </dl>
 </div>
 
@@ -653,10 +649,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>How to test</dt>
       <dd>
-         <ul>
-            <li> Step 1: A request to the base url MUST give a response and include the header "API-Version".</li>
-            <li> Step 2: The value of the header "API-Version" MUST have a valid Semantic Versioning number.</li>
-         </ul>
+         A response MUST include the header "API-Version".
       </dd>
    </dl>
 </div>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -104,7 +104,7 @@ A resource describing a single thing is called a [=singular resource=]. Resource
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -194,7 +194,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific testscripts are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific testscripts are published in the [[ADR-Validator]] repository.
       </dd>
    <div class="example">The following table shows some examples of the use of standard HTTP methods:
       <table>
@@ -421,7 +421,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -473,7 +473,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -550,7 +550,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -594,7 +594,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -622,7 +622,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule can be tested automaticaly and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -240,7 +240,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
   If an optional HTTP request method is sent to a server and the server does not support that HTTP method for the target resource, an HTTP status code <code>405 Method Not Allowed</code> shall be returned and a list of allowed methods for the target resource shall be provided in the <code>Allow</code> header in the response as stated in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5">RFC 7231 6.5.5</a>.</p>
       <dt>How to test</dt>
       <dd>
-         The open api specification MUST NOT include non standard HTTP methods for retrieving or manipulating resources.
+         The OpenAPI Description MUST NOT include non standard HTTP methods for retrieving or manipulating resources.
       </dd>
    </dl>
 </div>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -104,7 +104,7 @@ A resource describing a single thing is called a [=singular resource=]. Resource
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L203">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>      
       <dt>How to test</dt>
       <dd>
@@ -199,7 +199,7 @@ Although the REST architectural style does not impose a specific protocol, REST 
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L60">here</a>. The specific testscripts are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific testscripts are published in the [[ADR-Validator]] repository.
       </dd>
    <div class="example">The following table shows some examples of the use of standard HTTP methods:
       <table>
@@ -444,7 +444,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L123">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -496,7 +496,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L257">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -573,7 +573,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L164">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -617,7 +617,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L322">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>
@@ -649,7 +649,7 @@ Changes in APIs are inevitable. APIs should therefore always be versioned, facil
       </dd>
       <dt>Implications</dt>
       <dd>
-         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The source code of the technical test can be found <a href="https://gitlab.com/commonground/don/adr-validator/-/blob/v0.5.0/pkg/rulesets/core/rules.go#L354">here</a>. The specific tests are published in the [[ADR-Validator]] repository.
+         This rule is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
       </dd>
       <dt>How to test</dt>
       <dd>


### PR DESCRIPTION
Als voorbereiding op de behandeling van de standaard door het Forum Standaardisatie en de doorontwikkeling van developer.overheid zijn de deeplinks naar de testcode verwijdert en zijn de tests algemener beschreven. Dit geeft developer.overheid meer vrijheid om verschillende manieren van testen op te zetten en uit te werken. 

Conform de geest van de design rules zijn de tests meer gericht op het testen van het design aan de hand van de Open API Specification, dan aan het testen van de server configuratie waarop de API draait. ook het onderscheid tussen het design en de implementatie is niet aan ons om te testen. vandaar de focus op het design en de OAS.

Deze wijzigingen zijn ingegeven door de issues van @dvh zoals gebundeld in https://github.com/Geonovum/KP-APIs/milestone/4

De wijzigingen betreffen GEEN inhoudelijke wijzigingen van de standaard, het is slechts een aanpassing in verwijzingen naar externe bronnen en informatieve manieren om de regels van de standaard te kunnen testen.