### PR TITLE
Editorial: sta issues op standaard repository toe

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Kennisplatform APIs Issue base
-    url: https://github.com/Geonovum/KP-APIs/issues/
-    about: Please submit issues here.


### PR DESCRIPTION
Voor issues gerelateerd tot beheer moeten
issues op de repository aangemaakt ipv op het kennisplatform.
Daarmee maken we een scheiding tussen inhoudelijke
vraagstukken omtrent de content van de standaard
en vraagstukken enkel gerelateerd aan beheer.