### PR TITLE
Voeg RELEASING.md toe

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,7 +45,7 @@ Compliance aan de ADR heeft daarom de volgende eigenschappen:
   * Dit betekent dat de compliance checks draaien op de nieuwe patch versie dezelfde score oplevert.
 * Bestaande design rules in een nieuwe minor versie zullen dezelfde resultaten opleveren als eerdere minor versies binnen de major release.
 Nieuwe design rules in een minor versie kunnen in een kleine minderheid resulteren in nieuwe issues.
-  * Dit betekent dat in de meeste gevallen de compliance checks draaien op de nieuwe versie, deze meestal dezelfde score oplevert.
+  * Dit betekent dat in de meeste gevallen dat compliance checks draaien op de nieuwe versie, deze meestal dezelfde score oplevert.
   Echter, er kunnen situaties zijn waar bestaande API's op enkele nieuwe regels niet direct compliant zijn.
 * Design rules in een nieuwe major versie kunnen andere resultaten opleveren.
 Hierbij wordt de impact afgewogen ten opzichte van de waarde van de nieuwe design rule.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Release procedure
+
+Om een nieuwe versie van deze standaard te publiceren, moeten er nieuwe commits op `main` worden gepusht.
+Dit kan zowel met een losstaande PR (in het geval van kleine patch fixes) of het synchroniseren van `develop` als er een minor/major release klaar wordt gezet.
+
+# Versioning van deze standaard
+
+Deze standaard volgt het [API-standaarden beheermodel](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/).
+Dit betekent dat deze standaard Semantic Versioning gebruikt in de vorm van MAJOR.MINOR.PATCH.
+
+Hierbij is er wel ambiguiteit in wat Minor versus Major changes zijn, aangezien nieuwe design rules een kleine of grote impact kunnen hebben op bestaande APIs die conform de API Design Rules zijn gebouwd.
+Om deze ambiguiteit te verduidelijken beschrijven we in deze sectie wat wel en niet valt onder Major, Minor en Patch changes bij het toevoegen van nieuwe design rules.
+
+Het wijzigen van bestaande design rules blijft een Major release.
+
+## Het toevoegen van een nieuwe design rule is Minor, tenzij grote impact wordt verwacht
+
+Aangezien deze standaard allerlei design rules specificeert, komt het regelmatig voor dat nieuwe regels worden toegepast op basis van kennis opgedaan van bestaande implementaties.
+Hierbij kan het voorkomen dat bestaande implementaties niet meer voldoen aan een nieuwe set van regels in een nieuwe versie.
+
+Op basis van de analyse van leden van het TO, Beheer en publieke consultatie word de impact van de nieuwe regel beoordeeld.
+Als een nieuwe regel een verwachte minimale impact heeft, dan kan hij onderdeeld zijn van een Minor release.
+
+### Voorbeeld: gebruik standaard HTTP methodes is Minor
+
+APIs worden vrijwel altijd met HTTP methodes geimplementeerd.
+Het expliciet maken van deze requirement voorkomt ambiguiteit en heeft een verwachte kleine impact.
+Een nieuwe versie van de standaard mag een Minor version zijn, omdat de intentie (en verwachting) is dat bestaande APIs grotendeels compatibel zijn.
+
+### Voorbeeld: vereis versie nummer in de URI is Major
+
+Het is een semantische kwestie of het versie nummer van een API in de URI moet.
+Dit betekent dat er in principe geen industrie-wijd concensus is over het wel, dan wel niet, toevoegen van een versie nummer in de URI.
+Bestaande APIs kunnen hier een andere keuze in hebben gemaakt (lees wel: dit is een potentiele situatie, de design rules hebben van de start deze rule bevat) en impact kan dus groot zijn.
+Vooral voor APIs die al (veel) gebruikers hebben die moeten migreren naar nieuwe URIs.
+Omdat de verwachte impact groot is voor organisaties, zou het toevoegen van deze design rule onderdeel zijn van een Major release.
+
+## Interpretatie van versioning scheme wat betreft compliance
+
+Aangezien de regels in de toekomst kunnen worden uitgebreid is compliance gelinkt aan versions van de standaard.
+Compliance aan de ADR heeft daarom de volgende eigenschappen:
+
+* Alle design rules in een nieuwe patch versie zullen dezelfde resultaten opleveren als eerdere patch versies binnen de minor release
+  * Dit betekent dat de compliance checks draaien op de nieuwe patch versie dezelfde score oplevert
+* Bestaande design rules in een nieuwe minor versie zullen dezelfde resultaten opleveren als eerdere minor versies binnen de major release.
+Nieuwe design rules in een minor versie kunnen in een kleine minderheid resulteren in nieuwe issues
+  * Dit betekent dat in de meeste gevallen de compliance checks draaien op de nieuwe versie, deze meestal dezelfde score oplevert.
+  Echter, er kunnen situaties zijn waar bestaande APIs op enkele nieuwe regels niet direct compliant zijn.
+  Als dit het geval is, zal dit in de minderheid van bestaande APIs zijn
+* Design rules in een nieuwe major versie kunnen andere resultaten opleveren
+Hierbij wordt de impact afgewogen ten opzichte van de waarde van de nieuwe design rule.
+Dit kunnen zowel nieuwe design rules die een verwachte grote impact hebben, of wijzigingen aan bestaande design rules.
+
+## Waarom wordt hier afgeweken van strict Semantic Versioning?
+
+Het doel van Semantic Versioning is om inzicht te krijgen in de potentiele impact van een nieuwe versie voor de eindgebruiker.
+Het versienummer is een communicatiemiddel tussen de maintainer en gebruiker.
+Een Major version geeft een signaal af aan de gebruiker dat er een grote impact wordt verwacht.
+
+Deze standaard bevat design rules die limiterend zijn in welke keuzes beheerders van APIs kunnen nemen.
+Dit betekent dat keuzes van beheerders in het verleden mogelijk niet meer toe gestaan worden op basis van nieuwe inzichten.
+Als Semantic Versioning strict wordt gevolgd, dan resulteert dit in (zeer) frequente Major releases, aangezien nieuwe regels potentieel bestaande APIs non-compliant kunnen maken.
+Het gevolg is dat elke nieuwe design rule van deze standaard een Major release introduceert.
+Dit is in strijd met de intentie van Semantic Versioning, omdat hiermee de verwachtingen voor gebruikers onduidelijk wordt.
+Niet alle nieuwe design rules hebben dezelfde impact, sommige mogelijk helemaal geen (bijvoorbeeld als er gesproken word over "industry-standard").
+
+Om beheerders van APIs zo goed mogelijk te informeren over de impact van wijzigingen wordt er dus gekeken naar potentiele praktische impact in plaats van theoretische impact.
+Deze praktische impact wordt bepaald op basis van input van beheerders van bestaande APIs via de, door de governance bepaalde, relevante gremia.
+Hierbij is het speerpunt dat impact voor beheerders duidelijk moet zijn zodat inschattingen voor planning en prioritisering haalbaar zijn.
+Deze impact inschatting is onhaalbaar als elke release een nieuwe Major version zou opleveren.
+
+Al met al zorgt dit ervoor dat de intentie van een release begrijpelijk is voor API beheerders.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,36 +8,37 @@ Dit kan zowel met een losstaande PR (in het geval van kleine patch fixes) of het
 Deze standaard volgt het [API-standaarden beheermodel](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/).
 Dit betekent dat deze standaard Semantic Versioning gebruikt in de vorm van MAJOR.MINOR.PATCH.
 
-Hierbij is er wel ambiguiteit in wat Minor versus Major changes zijn, aangezien nieuwe design rules een kleine of grote impact kunnen hebben op bestaande APIs die conform de API Design Rules zijn gebouwd.
+Hierbij is er wel ambiguiteit in wat Minor versus Major changes zijn, aangezien nieuwe design rules een kleine of grote impact kunnen hebben op bestaande API's die conform de API Design Rules zijn gebouwd.
 Om deze ambiguiteit te verduidelijken beschrijven we in deze sectie wat wel en niet valt onder Major, Minor en Patch changes bij het toevoegen van nieuwe design rules.
 
 Het wijzigen van bestaande design rules blijft een Major release.
 
-## Het toevoegen van een nieuwe design rule is Minor, tenzij grote impact wordt verwacht
+## Semantic versioning hangt af van of een API client moet worden aangepast
 
 Aangezien deze standaard allerlei design rules specificeert, komt het regelmatig voor dat nieuwe regels worden toegepast op basis van kennis opgedaan van bestaande implementaties.
-Hierbij kan het voorkomen dat bestaande implementaties niet meer voldoen aan een nieuwe set van regels in een nieuwe versie.
+Hierbij kan het voorkomen dat bestaande API's niet meer voldoen aan een nieuwe set van regels in een nieuwe versie.
 
 Op basis van de analyse van leden van het TO, Beheer en publieke consultatie word de impact van de nieuwe regel beoordeeld.
-Als een nieuwe regel een verwachte minimale impact heeft, dan kan hij onderdeeld zijn van een Minor release.
+Als een nieuwe regel voor bestaande clients van een API veranderingen vereist, dan is de nieuwe versie Major.
+Echter, als een nieuwe regel enkel veranderingen vereist aan een API en voor de rest niet resulteren in veranderingen van een API client, dan is de nieuwe versie Minor.
 
 ### Voorbeeld: gebruik standaard HTTP methodes is Minor
 
-APIs worden vrijwel altijd met HTTP methodes geimplementeerd.
-Het expliciet maken van deze requirement voorkomt ambiguiteit en heeft een verwachte kleine impact.
-Een nieuwe versie van de standaard mag een Minor version zijn, omdat de intentie (en verwachting) is dat bestaande APIs grotendeels compatibel zijn.
+API's worden vrijwel altijd met HTTP methodes geimplementeerd.
+Het expliciet maken van deze requirement voorkomt ambiguiteit en API clients maken hier praktisch altijd gebruik van.
+Een nieuwe versie van de standaard mag een Minor version zijn, omdat de intentie (en verwachting) is dat bestaande API clients compatibel zijn.
 
 ### Voorbeeld: vereis versie nummer in de URI is Major
 
 Het is een semantische kwestie of het versie nummer van een API in de URI moet.
 Dit betekent dat er in principe geen industrie-wijd concensus is over het wel, dan wel niet, toevoegen van een versie nummer in de URI.
-Bestaande APIs kunnen hier een andere keuze in hebben gemaakt (lees wel: dit is een potentiele situatie, de design rules hebben van de start deze rule bevat) en impact kan dus groot zijn.
-Vooral voor APIs die al (veel) gebruikers hebben die moeten migreren naar nieuwe URIs.
-Omdat de verwachte impact groot is voor organisaties, zou het toevoegen van deze design rule onderdeel zijn van een Major release.
+Bestaande API's kunnen hier een andere keuze in hebben gemaakt (lees wel: dit is een potentiele situatie, de design rules hebben van de start deze rule bevat).
+Hierdoor is het goed mogelijk dat API clients de URL moeten veranderen.
+Daarom zou het toevoegen van deze design rule onderdeel zijn van een Major release.
 
 ## Interpretatie van versioning scheme wat betreft compliance
 
-Aangezien de regels in de toekomst kunnen worden uitgebreid is compliance gelinkt aan versions van de standaard.
+Aangezien de regels in de toekomst kunnen worden uitgebreid is compliance gelinkt aan versies van de standaard.
 Compliance aan de ADR heeft daarom de volgende eigenschappen:
 
 * Alle design rules in een nieuwe patch versie zullen dezelfde resultaten opleveren als eerdere patch versies binnen de minor release
@@ -45,28 +46,27 @@ Compliance aan de ADR heeft daarom de volgende eigenschappen:
 * Bestaande design rules in een nieuwe minor versie zullen dezelfde resultaten opleveren als eerdere minor versies binnen de major release.
 Nieuwe design rules in een minor versie kunnen in een kleine minderheid resulteren in nieuwe issues
   * Dit betekent dat in de meeste gevallen de compliance checks draaien op de nieuwe versie, deze meestal dezelfde score oplevert.
-  Echter, er kunnen situaties zijn waar bestaande APIs op enkele nieuwe regels niet direct compliant zijn.
-  Als dit het geval is, zal dit in de minderheid van bestaande APIs zijn
+  Echter, er kunnen situaties zijn waar bestaande API's op enkele nieuwe regels niet direct compliant zijn.
 * Design rules in een nieuwe major versie kunnen andere resultaten opleveren
 Hierbij wordt de impact afgewogen ten opzichte van de waarde van de nieuwe design rule.
-Dit kunnen zowel nieuwe design rules die een verwachte grote impact hebben, of wijzigingen aan bestaande design rules.
+Dit kunnen zowel nieuwe design rules die een verwachte grote impact hebben, veranderingen vereisen aan API clients of wijzigingen aan bestaande design rules.
 
-## Waarom wordt hier afgeweken van strict Semantic Versioning?
+## Waarom wordt hier afgeweken van strict Semantic Versioning op basis van enkel de API's zelf?
 
 Het doel van Semantic Versioning is om inzicht te krijgen in de potentiele impact van een nieuwe versie voor de eindgebruiker.
 Het versienummer is een communicatiemiddel tussen de maintainer en gebruiker.
 Een Major version geeft een signaal af aan de gebruiker dat er een grote impact wordt verwacht.
 
-Deze standaard bevat design rules die limiterend zijn in welke keuzes beheerders van APIs kunnen nemen.
+Deze standaard bevat design rules die limiterend zijn in welke keuzes beheerders van API's kunnen nemen.
 Dit betekent dat keuzes van beheerders in het verleden mogelijk niet meer toe gestaan worden op basis van nieuwe inzichten.
-Als Semantic Versioning strict wordt gevolgd, dan resulteert dit in (zeer) frequente Major releases, aangezien nieuwe regels potentieel bestaande APIs non-compliant kunnen maken.
+Als Semantic Versioning strict wordt gevolgd, dan resulteert dit in (zeer) frequente Major releases, aangezien nieuwe regels potentieel bestaande API's non-compliant kunnen maken.
 Het gevolg is dat elke nieuwe design rule van deze standaard een Major release introduceert.
 Dit is in strijd met de intentie van Semantic Versioning, omdat hiermee de verwachtingen voor gebruikers onduidelijk wordt.
 Niet alle nieuwe design rules hebben dezelfde impact, sommige mogelijk helemaal geen (bijvoorbeeld als er gesproken word over "industry-standard").
 
-Om beheerders van APIs zo goed mogelijk te informeren over de impact van wijzigingen wordt er dus gekeken naar potentiele praktische impact in plaats van theoretische impact.
-Deze praktische impact wordt bepaald op basis van input van beheerders van bestaande APIs via de, door de governance bepaalde, relevante gremia.
+Om gebruikers van API's zo goed mogelijk te informeren over de impact van wijzigingen wordt er dus gekeken naar de impact op de API clients.
+Deze client impact wordt bepaald op basis van input van beheerders van bestaande API's via de, door de governance bepaalde, relevante gremia.
 Hierbij is het speerpunt dat impact voor beheerders duidelijk moet zijn zodat inschattingen voor planning en prioritisering haalbaar zijn.
 Deze impact inschatting is onhaalbaar als elke release een nieuwe Major version zou opleveren.
 
-Al met al zorgt dit ervoor dat de intentie van een release begrijpelijk is voor API beheerders.
+Al met al zorgt dit ervoor dat de intentie van een release begrijpelijk is voor API beheerders en afnemers.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,8 @@ Dit kan zowel met een losstaande PR (in het geval van kleine patch fixes) of het
 Deze standaard volgt het [API-standaarden beheermodel](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/).
 Dit betekent dat deze standaard Semantic Versioning gebruikt in de vorm van MAJOR.MINOR.PATCH.
 
-Hierbij is er wel ambiguiteit in wat Minor versus Major changes zijn, aangezien nieuwe design rules een kleine of grote impact kunnen hebben op bestaande API's die conform de API Design Rules zijn gebouwd.
-Om deze ambiguiteit te verduidelijken beschrijven we in deze sectie wat wel en niet valt onder Major, Minor en Patch changes bij het toevoegen van nieuwe design rules.
+Hierbij is er wel ambiguïteit in wat Minor versus Major changes zijn, aangezien nieuwe design rules een kleine of grote impact kunnen hebben op bestaande API's die conform de API Design Rules zijn gebouwd.
+Om deze ambiguïteit te verduidelijken beschrijven we in deze sectie wat wel en niet valt onder Major, Minor en Patch changes bij het toevoegen van nieuwe design rules.
 
 Het wijzigen van bestaande design rules blijft een Major release.
 
@@ -18,21 +18,21 @@ Het wijzigen van bestaande design rules blijft een Major release.
 Aangezien deze standaard allerlei design rules specificeert, komt het regelmatig voor dat nieuwe regels worden toegepast op basis van kennis opgedaan van bestaande implementaties.
 Hierbij kan het voorkomen dat bestaande API's niet meer voldoen aan een nieuwe set van regels in een nieuwe versie.
 
-Op basis van de analyse van leden van het TO, Beheer en publieke consultatie word de impact van de nieuwe regel beoordeeld.
+Op basis van de analyse van leden van het TO, Beheer en publieke consultatie wordt de impact van de nieuwe regel beoordeeld.
 Als een nieuwe regel voor bestaande clients van een API veranderingen vereist, dan is de nieuwe versie Major.
 Echter, als een nieuwe regel enkel veranderingen vereist aan een API en voor de rest niet resulteren in veranderingen van een API client, dan is de nieuwe versie Minor.
 
-### Voorbeeld: gebruik standaard HTTP methodes is Minor
+### Voorbeeld: gebruik standaard HTTP-methodes is Minor
 
-API's worden vrijwel altijd met HTTP methodes geimplementeerd.
-Het expliciet maken van deze requirement voorkomt ambiguiteit en API clients maken hier praktisch altijd gebruik van.
+API's worden vrijwel altijd met HTTP-methodes geïmplementeerd.
+Het expliciet maken van deze requirement voorkomt ambiguïteit en API clients maken hier praktisch altijd gebruik van.
 Een nieuwe versie van de standaard mag een Minor version zijn, omdat de intentie (en verwachting) is dat bestaande API clients compatibel zijn.
 
-### Voorbeeld: vereis versie nummer in de URI is Major
+### Voorbeeld: vereis versienummer in de URI is Major
 
-Het is een semantische kwestie of het versie nummer van een API in de URI moet.
-Dit betekent dat er in principe geen industrie-wijd concensus is over het wel, dan wel niet, toevoegen van een versie nummer in de URI.
-Bestaande API's kunnen hier een andere keuze in hebben gemaakt (lees wel: dit is een potentiele situatie, de design rules hebben van de start deze rule bevat).
+Het is een semantische kwestie of het versienummer van een API in de URI moet.
+Dit betekent dat er in principe geen industrie-wijd consensus is over het wel, dan wel niet, toevoegen van een versienummer in de URI.
+Bestaande API's kunnen hier een andere keuze in hebben gemaakt (lees wel: dit is een potentiële situatie; De design rules hebben van de start deze rule bevat).
 Hierdoor is het goed mogelijk dat API clients de URL moeten veranderen.
 Daarom zou het toevoegen van deze design rule onderdeel zijn van een Major release.
 
@@ -41,19 +41,19 @@ Daarom zou het toevoegen van deze design rule onderdeel zijn van een Major relea
 Aangezien de regels in de toekomst kunnen worden uitgebreid is compliance gelinkt aan versies van de standaard.
 Compliance aan de ADR heeft daarom de volgende eigenschappen:
 
-* Alle design rules in een nieuwe patch versie zullen dezelfde resultaten opleveren als eerdere patch versies binnen de minor release
-  * Dit betekent dat de compliance checks draaien op de nieuwe patch versie dezelfde score oplevert
+* Alle design rules in een nieuwe patch versie zullen dezelfde resultaten opleveren als eerdere patch versies binnen de minor release.
+  * Dit betekent dat de compliance checks draaien op de nieuwe patch versie dezelfde score oplevert.
 * Bestaande design rules in een nieuwe minor versie zullen dezelfde resultaten opleveren als eerdere minor versies binnen de major release.
-Nieuwe design rules in een minor versie kunnen in een kleine minderheid resulteren in nieuwe issues
+Nieuwe design rules in een minor versie kunnen in een kleine minderheid resulteren in nieuwe issues.
   * Dit betekent dat in de meeste gevallen de compliance checks draaien op de nieuwe versie, deze meestal dezelfde score oplevert.
   Echter, er kunnen situaties zijn waar bestaande API's op enkele nieuwe regels niet direct compliant zijn.
-* Design rules in een nieuwe major versie kunnen andere resultaten opleveren
+* Design rules in een nieuwe major versie kunnen andere resultaten opleveren.
 Hierbij wordt de impact afgewogen ten opzichte van de waarde van de nieuwe design rule.
 Dit kunnen zowel nieuwe design rules die een verwachte grote impact hebben, veranderingen vereisen aan API clients of wijzigingen aan bestaande design rules.
 
 ## Waarom wordt hier afgeweken van strict Semantic Versioning op basis van enkel de API's zelf?
 
-Het doel van Semantic Versioning is om inzicht te krijgen in de potentiele impact van een nieuwe versie voor de eindgebruiker.
+Het doel van Semantic Versioning is om inzicht te krijgen in de potentiële impact van een nieuwe versie voor de eindgebruiker.
 Het versienummer is een communicatiemiddel tussen de maintainer en gebruiker.
 Een Major version geeft een signaal af aan de gebruiker dat er een grote impact wordt verwacht.
 
@@ -62,11 +62,11 @@ Dit betekent dat keuzes van beheerders in het verleden mogelijk niet meer toe ge
 Als Semantic Versioning strict wordt gevolgd, dan resulteert dit in (zeer) frequente Major releases, aangezien nieuwe regels potentieel bestaande API's non-compliant kunnen maken.
 Het gevolg is dat elke nieuwe design rule van deze standaard een Major release introduceert.
 Dit is in strijd met de intentie van Semantic Versioning, omdat hiermee de verwachtingen voor gebruikers onduidelijk wordt.
-Niet alle nieuwe design rules hebben dezelfde impact, sommige mogelijk helemaal geen (bijvoorbeeld als er gesproken word over "industry-standard").
+Niet alle nieuwe design rules hebben dezelfde impact, sommige mogelijk helemaal geen (bijvoorbeeld als er gesproken word over "industry standard").
 
 Om gebruikers van API's zo goed mogelijk te informeren over de impact van wijzigingen wordt er dus gekeken naar de impact op de API clients.
 Deze client impact wordt bepaald op basis van input van beheerders van bestaande API's via de, door de governance bepaalde, relevante gremia.
 Hierbij is het speerpunt dat impact voor beheerders duidelijk moet zijn zodat inschattingen voor planning en prioritisering haalbaar zijn.
 Deze impact inschatting is onhaalbaar als elke release een nieuwe Major version zou opleveren.
 
-Al met al zorgt dit ervoor dat de intentie van een release begrijpelijk is voor API beheerders en afnemers.
+Al met al zorgt dit ervoor dat de intentie van een release begrijpelijk is voor API-beheerders en afnemers.


### PR DESCRIPTION
Hiermee maken we duidelijk hoe Semantic Versioning wordt
toegepast met betrekking tot nieuwe design rules. Dit voorkomt
de situatie dat elke nieuwe design rule een major release tot
gevolg heeft.