### PR TITLE
Voeg contact informatie toe aan OpenAPI document

### DIFF
--- a/DesignRules.md
+++ b/DesignRules.md
@@ -439,7 +439,7 @@ An API is as good as the accompanying documentation. The documentation has to be
   <dl>
       <dt>Statement</dt>
       <dd>
-         OpenAPI definition document SHOULD include the <a href="https://spec.openapis.org/oas/v3.0.1.html#contact-object"><code>info.contact</code></a> object for publicly available APIs.
+         OpenAPI definition document SHOULD include the <a href="https://spec.openapis.org/oas/v3.0.1.html#contact-object"><code>info.contact</code></a> object for publicly available APIs. Contact information SHOULD NOT be a generic contact address for the whole organisation.
       </dd>
       <dt>Rationale</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -443,7 +443,15 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Rationale</dt>
       <dd>
-         The OpenAPI Specification (OAS) [[OPENAPIS]] can include contact information to make clear how to reach out to API owners in case of issues or questions. This is relevant for publicly available APIs (such as OData) where no pre-existing communication channel exists between provider and consumer of the API. For internal APIs (where communication channels such as chat or issue trackers can suffice), the <code>info.contact</code> MAY be provided.
+         The OpenAPI Specification (OAS) [[OPENAPIS]] can include contact information to make clear how to reach out to API owners in case of issues or questions. This is relevant for publicly available APIs (such as OData) where no pre-existing communication channel exists between provider and consumer of the API. For internal APIs (where communication channels such as chat or issue trackers are likely already known), the <code>info.contact</code> MAY be provided.
+         <div class="example">
+            <p>Relevant contact information can include an email address and issue tracker.</p>
+            <pre><code class="json">{
+  "name": "Gebouwen API beheerder",
+  "url": "https://www.github.com/ministerie/gebouwen/issues",
+  "email": "teamgebouwen@ministerie.nl"
+}</code></pre>
+         </div>
       </dd>
       <dt>Implications</dt>
       <dd>

--- a/DesignRules.md
+++ b/DesignRules.md
@@ -434,6 +434,27 @@ An API is as good as the accompanying documentation. The documentation has to be
    </dl>
 </div>
 
+<div class="rule" id="/core/doc-openapi-contact" data-type="functional">
+  <p class="rulelab">Document contact information for publicly available APIs</p>
+  <dl>
+      <dt>Statement</dt>
+      <dd>
+         OpenAPI definition document SHOULD include the <a href="https://spec.openapis.org/oas/v3.0.1.html#contact-object"><code>info.contact</code></a> object for publicly available APIs.
+      </dd>
+      <dt>Rationale</dt>
+      <dd>
+         The OpenAPI Specification (OAS) [[OPENAPIS]] can include contact information to make clear how to reach out to API owners in case of issues or questions. This is relevant for publicly available APIs (such as OData) where no pre-existing communication channel exists between provider and consumer of the API. For internal APIs (where communication channels such as chat or issue trackers can suffice), the <code>info.contact</code> MAY be provided.
+      </dd>
+      <dt>Implications</dt>
+      <dd>
+         This rule can be tested automatically and an example of the test is included in the automatic tests on <a href="https://developer.overheid.nl/">developer.overheid.nl</a>. The specific tests are published in the [[ADR-Validator]] repository.
+      </dd>
+      <dt>How to test</dt>
+      <dd>
+      </dd>
+   </dl>
+</div>
+
 <span id="api-17"></span>
 <div class="rule" id="/core/doc-language" data-type="functional">
   <p class="rulelab">Publish documentation in Dutch unless there is existing documentation in English</p>


### PR DESCRIPTION
Hiermee wordt het voor publiek beschikbare APIs makkelijker
om contact op te zoeken met de owners als er vragen of
problemen zijn met deze API. Voor interne APIs waar er al
een communicatie kanaal bestaat (bijvoorbeeld voor een API
die binnen eenzelfde organisatie door 1 team wordt gebouwd)
is deze requirement niet nodig.

Fixes Geonovum/KP-APIs#638