### PR TITLE
Definieer nieuwe regel voor publiceren van landing page

### DIFF
--- a/examples/aspnet/ADR.csproj
+++ b/examples/aspnet/ADR.csproj
@@ -4,11 +4,14 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <OpenApiDocumentsDirectory>generated/</OpenApiDocumentsDirectory>
+    <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
+    <OpenApiGenerateDocumentsOptions>--file-name openapi</OpenApiGenerateDocumentsOptions>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/examples/aspnet/LandingPage.cs
+++ b/examples/aspnet/LandingPage.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace LandingPage.Controllers;
+
+[ApiController]
+[Route("/")]
+public class LandingPageController : ControllerBase
+{
+    [Tags("LandingPagina")]
+    [EndpointDescription("Landing pagina")]
+    [HttpGet(Name = "GetLandingPagina")]
+    public String Get()
+    {
+        return "Landing pagina";
+    }
+}

--- a/examples/aspnet/build-and-check-project.sh
+++ b/examples/aspnet/build-and-check-project.sh
@@ -6,37 +6,4 @@ cd $CURRENT_DIRECTORY
 # Bouw project
 dotnet build
 
-# Start the server als een background process
-dotnet run &
-SERVER_PID=$!
-
-mkdir -p generated/
-rm generated/openapi.json 2> /dev/null
-
-# Haal de gegenereerde openapi.json op. Omdat de server nog
-# moet opstarten slapen we 100 ms tussen elke call, totdat we
-# een succesvolle response terug krijgen.
-CURL_EXIT_CODE=1
-while [ $CURL_EXIT_CODE -ne 0 ]
-do
-    sleep 0.1
-    # Check of de server nog steeds draait. Als dat niet meer
-    # zo is, stop dan onmiddelijk met checken en downloaden van
-    # het openapi.json
-    ps -p $SERVER_PID 1> /dev/null
-    PROCESS_EXISTS=$(echo $?)
-    if [ $PROCESS_EXISTS -ne 0 ]
-    then
-        echo "Server has crashed. See above terminal output for more information"
-        exit 1
-    fi
-    curl --silent http://localhost:5009/openapi.json > generated/openapi.json
-    CURL_EXIT_CODE=$(echo $?)
-done
-
-# Stop het server background process, zonder de output naar de
-# terminal te printen
-kill $SERVER_PID
-wait $SERVER_PID 2>/dev/null
-
 ../run-spectral-linter.sh $(realpath generated/openapi.json)

--- a/examples/quarkus/src/main/java/org/acme/LandingPageResource.java
+++ b/examples/quarkus/src/main/java/org/acme/LandingPageResource.java
@@ -1,0 +1,31 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/")
+@Tag(name = "landing-page")
+public class LandingPageResource {
+
+    @GET
+    @Operation(description = "Landing page")
+    @APIResponse(
+            responseCode = "200",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN),
+            headers = {
+                @Header(
+                        name = OpenApiConstants.API_VERSION_HEADER_NAME,
+                        schema = @Schema(implementation = String.class))
+            })
+    public String landingPage() {
+        return "This is a landing page for this API.";
+    }
+}

--- a/js/config.js
+++ b/js/config.js
@@ -160,4 +160,14 @@ globalThis.respecConfig = {
 
   preProcess: [initializeHighlightJSYaml, fetchSpectralConfiguration],
   postProcess: [highlightSpectralCode, processRuleBlocks],
+
+  localBiblio: {
+    OData: {
+      authors: ["Michael Pizzo", "Ralf Handl", "Martin Zurmuehl"],
+      date: "23 April 2020",
+      href: "https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html",
+      publisher: "OASIS Standard",
+      title: "OData Version 4.01. Part 2: URL Conventions",
+    },
+  },
 };

--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -22,6 +22,9 @@ extends: spectral:oas
 rules:
   oas3-api-servers: error
 
+  #/core/no-trailing-slash
+  path-keys-no-trailing-slash: error
+
   #/core/doc-openapi
   openapi3:
     severity: error
@@ -67,18 +70,6 @@ rules:
         match: "\\/v[\\d+]"
       field: url
     message: "/core/uri-version: Include the major version number in the URI: https://logius-standaarden.github.io/API-Design-Rules/#/core/uri-version"
-
-  #/core/no-trailing-slash
-  paths-no-trailing-slash:
-    severity: error
-    given:
-      - "$.paths"
-    then:
-      function: pattern
-      functionOptions:
-        notMatch: ".+ \\/$"
-      field: "@key"
-    message: "/core/no-trailing-slash: Leave off trailing slashes from URIs: https://logius-standaarden.github.io/API-Design-Rules/#/core/no-trailing-slash"
 
   #/core/publish-openapi
   paths-open-api-json-resource-exists:
@@ -127,6 +118,25 @@ rules:
             - name
             - url
     message: "Missing fields in `info.contact` field. Must specify email, name and url."
+
+  #/core/doc-landing-page
+  missing-landing-page:
+    severity: error
+    given:
+      - "$.paths"
+    then:
+      field: "/"
+      function: truthy
+    message: "There does not exist a resource `/` that should resolve to the landing-page"
+
+  landing-page-no-get-response:
+    severity: error
+    given:
+      - "$.paths[/]"
+    then:
+      field: "get"
+      function: truthy
+    message: "There should be a GET endpoint for the `/` resource"
 
   #/core/http-methods
   http-methods:

--- a/linter/testcases/baseline/openapi.json
+++ b/linter/testcases/baseline/openapi.json
@@ -23,6 +23,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -47,6 +50,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/contact-missing/openapi.json
+++ b/linter/testcases/contact-missing/openapi.json
@@ -18,6 +18,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -42,6 +45,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/contact-no-email/openapi.json
+++ b/linter/testcases/contact-no-email/openapi.json
@@ -22,6 +22,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -46,6 +49,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/contact-no-name/openapi.json
+++ b/linter/testcases/contact-no-name/openapi.json
@@ -22,6 +22,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -46,6 +49,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/contact-no-url/openapi.json
+++ b/linter/testcases/contact-no-url/openapi.json
@@ -22,6 +22,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -46,6 +49,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/cor-api/expected-output.txt
+++ b/linter/testcases/cor-api/expected-output.txt
@@ -1,5 +1,6 @@
 
 /testcases/cor-api/openapi.json
+  37:13    error  missing-landing-page                     There does not exist a resource `/` that should resolve to the landing-page                                             paths
   70:35  warning  use-problem-schema                       The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./heartbeat.get.responses[429].content
   80:35  warning  use-problem-schema                       The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./heartbeat.get.responses[503].content
  154:35    error  paths-open-api-json-specify-cors-header  The response of the `/openapi.json` resource should set the `access-control-allow-origin` header with value `*`         paths./openapi.json.get.responses[200].headers
@@ -26,4 +27,4 @@
  734:35  warning  use-problem-schema                       The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./organisaties/{oin}.get.responses[500].content
  744:35  warning  use-problem-schema                       The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./organisaties/{oin}.get.responses[503].content
 
-✖ 25 problems (1 error, 24 warnings, 0 infos, 0 hints)
+✖ 26 problems (2 errors, 24 warnings, 0 infos, 0 hints)

--- a/linter/testcases/error-type/expected-output.txt
+++ b/linter/testcases/error-type/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/error-type/openapi.json
- 58:35  warning  use-problem-schema  The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./openapi.json.get.responses[400].content
+ 61:35  warning  use-problem-schema  The content type of an error response should be application/problem+json or application/problem+xml to match RFC 9457.  paths./openapi.json.get.responses[400].content
 
 ✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)

--- a/linter/testcases/error-type/openapi.json
+++ b/linter/testcases/error-type/openapi.json
@@ -23,6 +23,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -57,6 +60,33 @@
                         "description": "OK",
                         "content": {
                             "application/hal+json": {
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }

--- a/linter/testcases/landing-page-failure/expected-output.txt
+++ b/linter/testcases/landing-page-failure/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/landing-page-failure/openapi.json
+ 73:29  warning  operation-success-response  Operation must have at least one "2xx" or "3xx" response.  paths./.get.responses
+
+✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)

--- a/linter/testcases/landing-page-failure/openapi.json
+++ b/linter/testcases/landing-page-failure/openapi.json
@@ -8,11 +8,11 @@
             "url": "https://www.example.com",
             "email": "mail@example.com"
         },
-        "version": "1.0.0"
+        "version": "1.2.9-SNAPSHOT"
     },
     "servers": [
         {
-            "url": "https://example.com/api/v1"
+            "url": "https://oinregister.logius.nl/api/v1"
         }
     ],
     "security": [
@@ -62,39 +62,6 @@
                         "default": []
                     }
                 ]
-            },
-            "post": {
-                "tags": [
-                    "openapi"
-                ],
-                "description": "OpenAPI document",
-                "operationId": "pushOpenapiJSON",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "access-control-allow-origin": {
-                                "description": "Alle origins mogen bij deze resource",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
             }
         },
         "/": {
@@ -104,17 +71,8 @@
                 "description": "Landingpage with a description",
                 "operationId": "getLandingpage",
                 "responses": {
-                    "200": {
-                        "description": "Landingpage content",
-                        "headers": {
-                            "API-Version": {
-                                "description": "Current version",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
+                    "403": {
+                        "description": "Unauthorized"
                     }
                 },
                 "security": [
@@ -126,8 +84,6 @@
         }
     },
     "components": {
-        "schemas": {
-        },
         "securitySchemes": {
             "default": {
                 "type": "oauth2",

--- a/linter/testcases/landing-page-missing/expected-output.txt
+++ b/linter/testcases/landing-page-missing/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/landing-page-missing/openapi.json
+ 31:13  error  missing-landing-page  There does not exist a resource `/` that should resolve to the landing-page  paths
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/landing-page-missing/openapi.json
+++ b/linter/testcases/landing-page-missing/openapi.json
@@ -8,11 +8,11 @@
             "url": "https://www.example.com",
             "email": "mail@example.com"
         },
-        "version": "1.0.0"
+        "version": "1.2.9-SNAPSHOT"
     },
     "servers": [
         {
-            "url": "https://example.com/api/v1"
+            "url": "https://oinregister.logius.nl/api/v1"
         }
     ],
     "security": [
@@ -62,42 +62,9 @@
                         "default": []
                     }
                 ]
-            },
-            "post": {
-                "tags": [
-                    "openapi"
-                ],
-                "description": "OpenAPI document",
-                "operationId": "pushOpenapiJSON",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "access-control-allow-origin": {
-                                "description": "Alle origins mogen bij deze resource",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
             }
         },
-        "/": {
+        "/no-landing-page": {
             "get": {
                 "tags": ["Landingpage"],
                 "summary": "Landingpage",
@@ -126,8 +93,6 @@
         }
     },
     "components": {
-        "schemas": {
-        },
         "securitySchemes": {
             "default": {
                 "type": "oauth2",

--- a/linter/testcases/landing-page-no-get/expected-output.txt
+++ b/linter/testcases/landing-page-no-get/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/landing-page-no-get/openapi.json
+ 67:13  error  landing-page-no-get-response  There should be a GET endpoint for the `/` resource  paths./
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/landing-page-no-get/openapi.json
+++ b/linter/testcases/landing-page-no-get/openapi.json
@@ -8,11 +8,11 @@
             "url": "https://www.example.com",
             "email": "mail@example.com"
         },
-        "version": "1.0.0"
+        "version": "1.2.9-SNAPSHOT"
     },
     "servers": [
         {
-            "url": "https://example.com/api/v1"
+            "url": "https://oinregister.logius.nl/api/v1"
         }
     ],
     "security": [
@@ -62,43 +62,10 @@
                         "default": []
                     }
                 ]
-            },
-            "post": {
-                "tags": [
-                    "openapi"
-                ],
-                "description": "OpenAPI document",
-                "operationId": "pushOpenapiJSON",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "access-control-allow-origin": {
-                                "description": "Alle origins mogen bij deze resource",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
             }
         },
         "/": {
-            "get": {
+            "post": {
                 "tags": ["Landingpage"],
                 "summary": "Landingpage",
                 "description": "Landingpage with a description",
@@ -126,8 +93,6 @@
         }
     },
     "components": {
-        "schemas": {
-        },
         "securitySchemes": {
             "default": {
                 "type": "oauth2",

--- a/linter/testcases/open-api-missing/expected-output.txt
+++ b/linter/testcases/open-api-missing/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/open-api-missing/openapi.json
- 28:13  error  paths-open-api-json-resource-exists  There does not exist a resource `/openapi.json` that returns the OpenAPI specification document  paths
+ 31:13  error  paths-open-api-json-resource-exists  There does not exist a resource `/openapi.json` that returns the OpenAPI specification document  paths
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/open-api-missing/openapi.json
+++ b/linter/testcases/open-api-missing/openapi.json
@@ -23,9 +23,39 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
     },
     "components": {
         "schemas": {

--- a/linter/testcases/open-api-no-cors-header/expected-output.txt
+++ b/linter/testcases/open-api-no-cors-header/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/open-api-no-cors-header/openapi.json
- 40:35  error  paths-open-api-json-specify-cors-header  The response of the `/openapi.json` resource should set the `access-control-allow-origin` header with value `*`  paths./openapi.json.get.responses[200].headers
+ 43:35  error  paths-open-api-json-specify-cors-header  The response of the `/openapi.json` resource should set the `access-control-allow-origin` header with value `*`  paths./openapi.json.get.responses[200].headers
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/open-api-no-cors-header/openapi.json
+++ b/linter/testcases/open-api-no-cors-header/openapi.json
@@ -23,6 +23,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -40,6 +43,33 @@
                         "headers": {
                             "API-Version": {
                                 "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
                                 "style": "simple",
                                 "schema": {
                                     "type": "string"

--- a/linter/testcases/open-api-no-get/expected-output.txt
+++ b/linter/testcases/open-api-no-get/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/open-api-no-get/openapi.json
- 30:20  error  paths-open-api-json-resource-has-get  There does not exist a GET method (and no other methods) for the `/openapi.json` resource  paths./openapi.json.post
+ 33:20  error  paths-open-api-json-resource-has-get  There does not exist a GET method (and no other methods) for the `/openapi.json` resource  paths./openapi.json.post
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/open-api-no-get/openapi.json
+++ b/linter/testcases/open-api-no-get/openapi.json
@@ -23,6 +23,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -47,6 +50,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/open-api-with-additional-methods/expected-output.txt
+++ b/linter/testcases/open-api-with-additional-methods/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/open-api-with-additional-methods/openapi.json
- 63:20  error  paths-open-api-json-resource-has-get  There does not exist a GET method (and no other methods) for the `/openapi.json` resource  paths./openapi.json.post
+ 66:20  error  paths-open-api-json-resource-has-get  There does not exist a GET method (and no other methods) for the `/openapi.json` resource  paths./openapi.json.post
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-incorrect/expected-output.txt
+++ b/linter/testcases/paths-kebab-incorrect/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/paths-kebab-incorrect/openapi.json
- 67:25  warning  paths-kebab-case  /camelCasePad is not kebab-case.  paths./camelCasePad
+ 97:25  warning  paths-kebab-case  /camelCasePad is not kebab-case.  paths./camelCasePad
 
 ✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-incorrect/openapi.json
+++ b/linter/testcases/paths-kebab-incorrect/openapi.json
@@ -25,6 +25,9 @@
             "name": "openapi"
         },
         {
+            "name": "Landingpage"
+        },
+        {
             "name": "camelCase"
         }
     ],
@@ -50,6 +53,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/paths-kebab-slashes/expected-output.txt
+++ b/linter/testcases/paths-kebab-slashes/expected-output.txt
@@ -1,6 +1,6 @@
 
 /testcases/paths-kebab-slashes/openapi.json
-  96:26  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
- 154:37  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
+ 126:26  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
+ 184:37  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
 
-✖ 2 problems (0 errors, 2 warnings, 0 infos, 0 hints)
+✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-slashes/openapi.json
+++ b/linter/testcases/paths-kebab-slashes/openapi.json
@@ -25,6 +25,9 @@
             "name": "openapi"
         },
         {
+            "name": "Landingpage"
+        },
+        {
             "name": "slash"
         }
     ],
@@ -50,6 +53,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/paths-kebab-variables/openapi.json
+++ b/linter/testcases/paths-kebab-variables/openapi.json
@@ -25,6 +25,9 @@
             "name": "openapi"
         },
         {
+            "name": "Landingpage"
+        },
+        {
             "name": "variabele"
         }
     ],
@@ -50,6 +53,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/paths-kebab-zoek-uitzondering/openapi.json
- 125:19  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
+ 155:19  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
 
-✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-zoek-uitzondering/openapi.json
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/openapi.json
@@ -25,6 +25,9 @@
             "name": "openapi"
         },
         {
+            "name": "Landingpage"
+        },
+        {
             "name": "zoek"
         }
     ],
@@ -50,6 +53,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/servers-missing/openapi.json
+++ b/linter/testcases/servers-missing/openapi.json
@@ -19,6 +19,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -43,6 +46,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/linter/testcases/version-header-casing/openapi.json
+++ b/linter/testcases/version-header-casing/openapi.json
@@ -23,6 +23,9 @@
     "tags": [
         {
             "name": "openapi"
+        },
+        {
+            "name": "Landingpage"
         }
     ],
     "paths": {
@@ -47,6 +50,33 @@
                             },
                             "access-control-allow-origin": {
                                 "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": ["Landingpage"],
+                "summary": "Landingpage",
+                "description": "Landingpage with a description",
+                "operationId": "getLandingpage",
+                "responses": {
+                    "200": {
+                        "description": "Landingpage content",
+                        "headers": {
+                            "API-Version": {
+                                "description": "Current version",
+                                "style": "simple",
                                 "schema": {
                                     "type": "string"
                                 }

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -469,7 +469,7 @@ An API is as good as the accompanying documentation. The documentation has to be
       </dd>
       <dt>Rationale</dt>
       <dd>
-         <p> Clients (such as Swagger UI or ReDoc) MUST be able to retrieve the document without having to authenticate. Furthermore, the CORS policy for this [=URI=] MUST allow external domains to read the documentation from a browser environment.</p>
+         <p>Clients (such as Swagger UI or ReDoc) MUST be able to retrieve the document without having to authenticate. Furthermore, the CORS policy for this [=URI=] MUST allow external domains to read the documentation from a browser environment.</p>
          <p>The standard location for the OAS document is a URI called <code>openapi.json</code> or <code>openapi.yaml</code> within the base path of the API. This can be convenient, because OAS document updates can easily  become part of the CI/CD process.</p>
          <p>At least the JSON format MUST be supported. When having multiple (major) versions of an API, every API SHOULD provide its own OAS document(s).</p>
          <div class="example">
@@ -487,6 +487,35 @@ An API is as good as the accompanying documentation. The documentation has to be
             <li> Step 3: The openapi.yaml MUST contain the same OpenAPI Description as the openapi.json.</li>
             <li> Step 4: The CORS header Access-Control-Allow-Origin MUST allow all origins.</li>
          </ul>
+      </dd>
+   </dl>
+</div>
+
+<div class="rule" id="/core/doc-landing-page" data-type="technical">
+  <p class="rulelab">Publish root resource as landing page</p>
+  <dl>
+      <dt>Statement</dt>
+      <dd>
+         The root resource of an API (<code>/</code>) MUST have a GET endpoint which returns a response with a 200 or 30X status.
+      </dd>
+      <dt>Rationale</dt>
+      <dd>
+         <p>Consumers of an API need to know that the API exists. A landing page at the root resource (append <code>/</code> to the service root URL) MUST have a GET endpoint that returns a response with a 200 or 30X status. Furthermore, the CORS policy for this [=URI=] MUST allow external domains to read the documentation from a browser environment. Depending on your API, you SHOULD include one of the following options:
+         <ul>
+            <li>The root resource shows a landing page with documentation about the API</li>
+            <li>The root resource redirects to a landing page</li>
+            <li>The root resource returns data as part of your API contract</li>
+         </ul>
+         <p class="note">If this API implements the [[?OData]] specification, the landing page MUST show the OpenAPI specification document</li>
+         <div class="example">
+            <p>The root resource for an API published at <code>https://api.example.org/v1</code>:</p>
+            <pre class="nohighlight">https://api.example.org/v1/</pre>
+         </div>
+      </dd>
+      <dt>How to test</dt>
+      <dd>
+         <li>A GET request to the server root URL appended with a <code>/</code> MUST result in a HTTP 200 or 30X status</li>
+         <li>The CORS header Access-Control-Allow-Origin for this endpoint MUST allow all origins.</li>
       </dd>
    </dl>
 </div>


### PR DESCRIPTION
Deze nieuwe regel zorgt ervoor dat consumers de API kunnen vinden en informatie
over de API kunnen lezen. Als deze root resource niet gedefinieerd is (en dus in
bijvoorbeeld een 404 resulteren), kunnen consumers onbewust concluderen dat de
API niet bestaat, terwijl dat wel het geval is.

Tevens lossen we hiermee de ambiguiteit met de OData specificatie op, die aangeeft
dat de service root URL in een slash moet eindigen (en dus beschikbaar moet zijn).
Voor OData APIs moet op deze root resource het OpenAPI specification document
gepubliceerd zijn.

Fixes Geonovum/KP-APIs#514
Fixes Geonovum/KP-APIs#530
Fixes Geonovum/KP-APIs#604
Fixes Geonovum/KP-APIs#624

Closes #164