### PR TITLE
Editorial: update beheermodel naar API-Standaarden (#154)

### DIFF
--- a/Abstract.md
+++ b/Abstract.md
@@ -1,3 +1,3 @@
-This document contains a normative standard for designing APIs in the Dutch Public Sector.  
-[The Governance of this standard](https://publicatie.centrumvoorstandaarden.nl/api/adr-beheer/) is described in a [separate repository](https://github.com/Logius-standaarden/ADR-Beheermodel) and published by Logius.  
-This document is part of the *Nederlandse API Strategie*, which consists of [a set of documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).  
+This document contains a normative standard for designing APIs in the Dutch Public Sector.
+[The Governance of this standard](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/) is described by the API-Standaarden beheermodel in a [separate repository](https://github.com/Logius-standaarden/API-Standaarden-Beheermodel/) and published by Logius.
+This document is part of the *Nederlandse API Strategie*, which consists of [a set of documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).

--- a/Governance/readme.md
+++ b/Governance/readme.md
@@ -2,11 +2,11 @@
 
 This folder used to hold concept information and documents related to the Governance of the API Design Rules Standard.  
   
-The governance documentation has been moved to a separate repository located at [https://github.com/Logius-standaarden/ADR-Beheermodel](https://github.com/Logius-standaarden/ADR-Beheermodel)  
-  
-> The final version is published at [https://logius-standaarden.github.io/ADR-Beheermodel/](https://logius-standaarden.github.io/ADR-Beheermodel/)  
+The governance documentation had been moved to a separate repository located at [https://github.com/Logius-standaarden/ADR-Beheermodel](https://github.com/Logius-standaarden/ADR-Beheermodel) and then superseded by the [API-Standaarden-Beheermodel](https://logius-standaarden.github.io/API-Standaarden-Beheermodel/).
 
-  
+> The final version is published at [https://logius-standaarden.github.io/API-Standaarden-Beheermodel/](https://logius-standaarden.github.io/API-Standaarden-Beheermodel/)
+
+
 ## More information
 
 For more information about het API Standards visit [https://www.logius.nl/diensten/api-standaarden](https://www.logius.nl/diensten/api-standaarden)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ De definitieve versie 2.0.0 is beschikbaar op: https://gitdocumentatie.logius.nl
 | 🏛️[NLGov OAuth 2.0 profile (OAuth)](https://forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oauth-20) | 🍿[OAuth v1 (definitief)](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) | ✍️[OAuth v1.1.0 (werkversie)](https://logius-standaarden.github.io/OAuth-NL-profiel/) | 🤓[OAuth-NL-profiel](https://github.com/Logius-standaarden/OAuth-NL-profiel) |
 | 🏛️[NLGov OpenID Connect profile (OIDC)](https://forumstandaardisatie.nl/open-standaarden/nl-gov-assurance-profile-oidc) | 🍿[OIDC v1.0.1 (definitief)](https://gitdocumentatie.logius.nl/publicatie/api/oidc/) | ✍️[OIDC v1.0.1 (werkversie)](https://logius-standaarden.github.io/OIDC-NLGOV/) | 🤓[OIDC-NLGOV](https://github.com/Logius-standaarden/OIDC-NLGOV) |
 
-Het **Beheermodel** voor deze standaarden is gepubliceerd op: https://gitdocumentatie.logius.nl/publicatie/api/adr-beheer/
+Het **Beheermodel** voor deze standaarden is gepubliceerd op: https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/
 
 ### Versie 2.0.0 Release notes
 


### PR DESCRIPTION
Bij het indienen van de 2.0 versie van deze
standaard is tevens besloten het beheermodel te
updaten van de ADR-beheermodel naar de standaard
beheermodel van API-standaarden. Daarmee voorkomen we duplicatie van beheermodelen en blijven we
up-to-date met andere standaarden die wel het
standaard beheermodel gebruiken.