### PR TITLE
Beheer: voeg linter checks toe voor `info.contact` regel

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -116,7 +116,6 @@ rules:
       function: schema
       functionOptions:
         schema:
-          type: object
           required:
             - email
             - name

--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -104,6 +104,25 @@ rules:
       field: "access-control-allow-origin"
     message: "The response of the `/openapi.json` resource should set the `access-control-allow-origin` header with value `*`"
 
+  #/core/doc-openapi-contact
+  # This rule exists in the base oas spectral linter set
+  info-contact: error
+
+  info-contact-fields-exist:
+    severity: error
+    given:
+      - "$.info.contact"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required:
+            - email
+            - name
+            - url
+    message: "Missing fields in `info.contact` field. Must specify email, name and url."
+
   #/core/http-methods
   http-methods:
     severity: error

--- a/linter/testcases/contact-missing/expected-output.txt
+++ b/linter/testcases/contact-missing/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/contact-missing/openapi.json
+ 3:12  error  info-contact  Info object must have "contact" object.  info
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/contact-missing/openapi.json
+++ b/linter/testcases/contact-missing/openapi.json
@@ -1,0 +1,75 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/contact-no-email/expected-output.txt
+++ b/linter/testcases/contact-no-email/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/contact-no-email/openapi.json
+ 6:19  error  info-contact-fields-exist  Missing fields in `info.contact` field. Must specify email, name and url.  info.contact
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/contact-no-email/openapi.json
+++ b/linter/testcases/contact-no-email/openapi.json
@@ -1,0 +1,79 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/contact-no-name/expected-output.txt
+++ b/linter/testcases/contact-no-name/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/contact-no-name/openapi.json
+ 6:19  error  info-contact-fields-exist  Missing fields in `info.contact` field. Must specify email, name and url.  info.contact
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/contact-no-name/openapi.json
+++ b/linter/testcases/contact-no-name/openapi.json
@@ -1,0 +1,79 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/contact-no-url/expected-output.txt
+++ b/linter/testcases/contact-no-url/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/contact-no-url/openapi.json
+ 6:19  error  info-contact-fields-exist  Missing fields in `info.contact` field. Must specify email, name and url.  info.contact
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/contact-no-url/openapi.json
+++ b/linter/testcases/contact-no-url/openapi.json
@@ -1,0 +1,79 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
De regel zit al in de ADR, maar was geintroduceerd voordat we de linter als bijlage hadden. Hiermee
hebben we nu ook de relevant regels in de linter.