### PR TITLE
Beheer: fix spectral check voor version header

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -31,16 +31,22 @@ rules:
       function: pattern
       functionOptions:
         match: "^3.0.*$"
-    message: "/core/doc-openapi: Use OpenAPI Specification for documentation: https://logius-standaarden.github.io/API-Design-Rules/#/core/doc-openapi"
+    message: "Use OpenAPI Specification for documentation"
 
   #/core/version-header
   missing-version-header:
     severity: error
     given: $..[responses][?(@property && @property.match(/(2|3)\d\d/))][headers]
     then:
-      field: API-Version
-      function: truthy
-    message: "/core/version-header: Return the full version number in a response header: https://logius-standaarden.github.io/API-Design-Rules/#/core/version-header"
+      function: or
+      functionOptions:
+        properties:
+          - API-Version
+          - Api-Version
+          - Api-version
+          - api-version
+          - API-version
+    message: "Return the full version number in a response header"
 
   missing-header:
     severity: error

--- a/linter/testcases/version-header-casing/expected-output.txt
+++ b/linter/testcases/version-header-casing/expected-output.txt
@@ -1,0 +1,1 @@
+No results with a severity of 'error' found!

--- a/linter/testcases/version-header-casing/openapi.json
+++ b/linter/testcases/version-header-casing/openapi.json
@@ -1,0 +1,80 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tijdens de impactanalyse kwamen we erachter dat sommige API's wel een version header terug geven, maar met een andere casing. Omdat headers geen casing hebben (dat wil zeggen dat clients case-insensitive er mee om moeten gaan) moeten we ze allemaal accepteren.

Helaas kunnen we bij een "present-in-object-check" geen casing of pattern matching doen. Dus daarom maar alle mogelijkheden uitgeschreven en de rest voldoet dan niet.