### PR TITLE
Beheer: voeg link-checker schedule toe

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   build:
     name: Build
-    uses: Logius-standaarden/Automatisering/.github/workflows/schedules/link-checker.yml@pr-timvdlippe-nieuwe-link-checker
+    uses: Logius-standaarden/Automatisering/.github/workflows/link-checker.yml@pr-timvdlippe-nieuwe-link-checker

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,11 @@
+name: Check published links
+on:
+  workflow_dispatch:
+  schedule:
+    # Run on Mondays at 5:45 UTC
+    - cron: '45 5 * * 1'
+
+jobs:
+  build:
+    name: Build
+    uses: Logius-standaarden/Automatisering/.github/workflows/schedules/link-checker.yml@pr-timvdlippe-nieuwe-link-checker

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   build:
     name: Build
-    uses: Logius-standaarden/Automatisering/.github/workflows/link-checker.yml@pr-timvdlippe-nieuwe-link-checker
+    uses: Logius-standaarden/Automatisering/.github/workflows/link-checker.yml@main
+    secrets: inherit


### PR DESCRIPTION
Gebruikt de link checker schedule uit Logius-standaarden/Automatisering#42 Hiermee checken we of de `api/adr` publicatie nog valide links heeft.