### PR TITLE
Beheer: update regex voor kebab-case

### DIFF
--- a/linter/run-linter-tests.mjs
+++ b/linter/run-linter-tests.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import {exec} from 'child_process';
 import utils from 'util';
 import * as path from 'path';

--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -143,11 +143,17 @@ rules:
   paths-kebab-case:
     severity: warn
     message: "{{property}} is not kebab-case."
-    given: $.paths[*]~
+    given: $.paths[?(@property && !@property.match(/\/openapi\.json/))]~
     then:
       function: pattern
       functionOptions:
-        match: /^(\/|[a-z0-9\-\.]+|{[a-zA-Z0-9]+})+$/
+        # Deze regex bestaat uit meerdere delen. Ter toelichting:
+        # - `\/` staat toe dat een pad enkel een `/` is (de landingspagina)
+        # - `\/_[a-z]+` staat toe dat het laatste stuk van een pad mag beginnen met een `_`
+        # - ([a-z\-]+|{[a-z]+}) zijn kebab-case paden of met variabele notatie (`{id}`)
+        # - Paden mogen nesten, waardoor de twee groep genest wordt, gescheiden met een `/`
+        # - Een pad mag eindigen met een `/`. Dat is volgens een andere regel niet toegestaan, maar we willen niet twee errors genereren
+        match: ^(\/|(\/_[a-z]+|\/(([a-z\-]+|{[a-z]+})(\/([a-z\-\.]+|{[a-z]+}))*)(\/_[a-z]+)?)\/?)$
 
   schema-camel-case:
     severity: warn

--- a/linter/testcases/paths-kebab-incorrect/expected-output.txt
+++ b/linter/testcases/paths-kebab-incorrect/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/paths-kebab-incorrect/openapi.json
+ 67:25  warning  paths-kebab-case  /camelCasePad is not kebab-case.  paths./camelCasePad
+
+✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-incorrect/openapi.json
+++ b/linter/testcases/paths-kebab-incorrect/openapi.json
@@ -1,0 +1,112 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        },
+        {
+            "name": "camelCase"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/camelCasePad": {
+            "get": {
+                "tags": [
+                    "camelCase"
+                ],
+                "description": "camelCase",
+                "operationId": "getCamelCase",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/paths-kebab-slashes/expected-output.txt
+++ b/linter/testcases/paths-kebab-slashes/expected-output.txt
@@ -1,0 +1,6 @@
+
+/testcases/paths-kebab-slashes/openapi.json
+  96:26  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
+ 154:37  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
+
+✖ 2 problems (0 errors, 2 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-slashes/openapi.json
+++ b/linter/testcases/paths-kebab-slashes/openapi.json
@@ -1,0 +1,199 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        },
+        {
+            "name": "slash"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/prefix-slash": {
+            "get": {
+                "tags": [
+                    "slash"
+                ],
+                "description": "slash",
+                "operationId": "getPrefixSlash",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/suffix-slash/": {
+            "get": {
+                "tags": [
+                    "slash"
+                ],
+                "description": "slash",
+                "operationId": "getSuffixSlash",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/nested-slash/achter": {
+            "get": {
+                "tags": [
+                    "slash"
+                ],
+                "description": "slash",
+                "operationId": "getNestedSlash",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/nested-slash/met-suffix/": {
+            "get": {
+                "tags": [
+                    "slash"
+                ],
+                "description": "slash",
+                "operationId": "getNestedSlashMetSuffix",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/paths-kebab-variables/expected-output.txt
+++ b/linter/testcases/paths-kebab-variables/expected-output.txt
@@ -1,0 +1,1 @@
+No results with a severity of 'error' found!

--- a/linter/testcases/paths-kebab-variables/openapi.json
+++ b/linter/testcases/paths-kebab-variables/openapi.json
@@ -1,0 +1,165 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        },
+        {
+            "name": "variabele"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/organisaties/{id}": {
+            "get": {
+                "tags": [
+                    "variabele"
+                ],
+                "description": "Met variabele",
+                "operationId": "getWithVariable",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "De variabele",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/organisaties/{id}/nested": {
+            "get": {
+                "tags": [
+                    "variabele"
+                ],
+                "description": "Met variabele nested",
+                "operationId": "getWithVariableNested",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "De variabele",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/paths-kebab-zoek-uitzondering/openapi.json
+ 125:19  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
+
+✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-zoek-uitzondering/openapi.json
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/openapi.json
@@ -1,0 +1,211 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        },
+        {
+            "name": "zoek"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/organisaties/_zoek": {
+            "get": {
+                "tags": [
+                    "zoek"
+                ],
+                "description": "Organisatie zoek operatie",
+                "operationId": "organisatieZoek",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/_zoek": {
+            "get": {
+                "tags": [
+                    "zoek"
+                ],
+                "description": "Globale zoekoperatie",
+                "operationId": "globalZoek",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/_zoek/": {
+            "get": {
+                "tags": [
+                    "zoek"
+                ],
+                "description": "Globale zoekoperatie met trailing",
+                "operationId": "globalZoekMetTrailing",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/organisaties/{id}/nested/_zoek": {
+            "get": {
+                "tags": [
+                    "zoek"
+                ],
+                "description": "Met variabele nested en zoek",
+                "operationId": "getWithVariableNestedEnZoek",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "De variabele",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Op basis van de impactanalyse blijkt dat API's nog redelijk vaak de conventie gebruiken voor `_zoek`. Dit komt uit de wereld van ElasticSearch. Tegelijkertijd kwamen er ook veel errors met trailing slashes. Ook al zijn trailing slashes niet toegestaan, moeten we ook niet dubbele errors hiervoor geven.

De regex is vrij complex geworden, dus ik heb met comments geprobeerd om het nog enigszins begrijpelijk te maken.