### PR TITLE
Beheer: fix export van `respecConfig`

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -103,7 +103,7 @@ function processRuleBlocks(config, document) {
   }
 }
 
-var respecConfig = {
+globalThis.respecConfig = {
   alternateFormats: [ { 
         "label" : "pdf",
         "uri" : "API-Design-Rules.pdf"


### PR DESCRIPTION
Nu is het in te lezen vanuit de link checker

Nu faalt hij hier nog op: https://github.com/Logius-standaarden/API-Design-Rules/actions/runs/14905664957/job/41867311127