### PR TITLE
Fix path regex op basis van impactanalyse

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -149,11 +149,11 @@ rules:
       functionOptions:
         # Deze regex bestaat uit meerdere delen. Ter toelichting:
         # - `\/` staat toe dat een pad enkel een `/` is (de landingspagina)
-        # - `\/_[a-z]+` staat toe dat het laatste stuk van een pad mag beginnen met een `_`
-        # - ([a-z\-]+|{[a-z]+}) zijn kebab-case paden of met variabele notatie (`{id}`)
+        # - `\/_[a-z0-9]+` staat toe dat het laatste stuk van een pad mag beginnen met een `_`
+        # - ([a-z0-9\-]+|{[^}]+}) zijn kebab-case paden of met variabele notatie (`{id}`)
         # - Paden mogen nesten, waardoor de twee groep genest wordt, gescheiden met een `/`
         # - Een pad mag eindigen met een `/`. Dat is volgens een andere regel niet toegestaan, maar we willen niet twee errors genereren
-        match: ^(\/|(\/_[a-z]+|\/(([a-z\-]+|{[a-z]+})(\/([a-z\-\.]+|{[a-z]+}))*)(\/_[a-z]+)?)\/?)$
+        match: ^(\/|(\/_[a-z0-9]+|\/(([a-z0-9\-]+|{[^}]+})(\/([a-z0-9\-\.]+|{[^}]+}))*)(\/_[a-z]+)?)\/?)$
 
   schema-camel-case:
     severity: warn

--- a/linter/testcases/paths-kebab-slashes/openapi.json
+++ b/linter/testcases/paths-kebab-slashes/openapi.json
@@ -179,6 +179,35 @@
                     }
                 ]
             }
+        },
+        "/v1/met-versie-nummer": {
+            "get": {
+                "tags": [
+                    "slash"
+                ],
+                "description": "slash",
+                "operationId": "getMetNestedVersieNummer",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
         }
     },
     "components": {

--- a/linter/testcases/paths-kebab-variables/openapi.json
+++ b/linter/testcases/paths-kebab-variables/openapi.json
@@ -145,6 +145,47 @@
                     }
                 ]
             }
+        },
+        "/organisaties/{organisationId}/pad": {
+            "get": {
+                "tags": [
+                    "variabele"
+                ],
+                "description": "Met camelCase variabele",
+                "operationId": "getWithCamelCaseVariable",
+                "parameters": [
+                    {
+                        "name": "organisationId",
+                        "in": "path",
+                        "description": "De variabele",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
         }
     },
     "components": {


### PR DESCRIPTION
Uit de impactanalyse kwamen nog enkele patronen die goed zouden zijn volgens de regel. Hiermee is de regex geupdate om die openapi.json incorrect zou behandelen als fout.