### PR TITLE
Voeg meer http methods toe aan core/http-methods

### DIFF
--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -218,12 +218,12 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 Although the REST architectural style does not impose a specific protocol, REST APIs are typically implemented using HTTP [[rfc9110]].
 
 <span id="api-03"></span>
-<div class="rule" id="/core/http-methods" data-type="technical">
+<div class="rule" id="/core/http-methods" data-type="functional">
    <p class="rulelab">Only apply standard HTTP methods</p>
    <dl>
       <dt>Statement</dt>
       <dd>
-         Resources MUST be retrieved or manipulated using standard HTTP methods (GET/POST/PUT/PATCH/DELETE).
+         An API MUST adhere to the HTTP method semantics defined in [[rfc9110]].
       </dd>
       <dt>Rationale</dt>
       <dd>


### PR DESCRIPTION
Hiermee maken we het expliciet dat ook de HTTP methods die enkel (metadata) informatie ophalen toegestaan zijn. Deze methoden maken geen wijzigingen of lezen resources uit, maar kunnen gebruikt worden om informatie over het endpoint zelf uit te lezen.

Fixes Geonovum/KP-APIs#633