### PR TITLE
`openapi3` rule herzien en nieuwe `openapi`-root property rule

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -25,13 +25,20 @@ rules:
   #/core/doc-openapi
   openapi3:
     severity: error
-    given:
-      - "$.['openapi']"
+    given: $.['openapi']
     then:
       function: pattern
       functionOptions:
-        match: "^3.0.*$"
-    message: "Use OpenAPI Specification for documentation"
+        match: '^3(.\d+){1,2}$'
+    message: "The OpenAPI Specification is versioned using a `major.minor.patch` versioning scheme. Use a version 3 OpenAPI Specification for documentation."
+
+  openapi-root-exists:
+    severity: error
+    given: $
+    then:
+      field: openapi
+      function: truthy
+    message: "The root of the document must contain the `openapi` property"
 
   #/core/version-header
   missing-version-header:


### PR DESCRIPTION
Lost #224 op.

De oas ruleset checkt trouwens al nauwkeuriger op versioning als de major versie een geldige versie is, via https://github.com/stoplightio/spectral/blob/a6653611bdc7d9d4d7e3f96dbae4eb63f2070e26/packages/rulesets/src/oas/functions/oasDocumentSchema.ts#L15 - maar als je bijv. `4.1.1` invult vind die ruleset het wel prima.

De wijziging aan de `openapi3` rule accepteert nu 3.x.x en 3.x, dus voldoet ruim aan wat er nu wordt voorgeschreven: https://spec.openapis.org/oas/v3.1.0.html#versions

`openapi-root-exists` checkt of de root property `openapi` bestaat, dit is iets wat niet standaard in de oas ruleset zit.