### PR TITLE
Beheer: specificeer casing voor schema's

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -134,7 +134,7 @@ rules:
 
   nlgov:schema-camel-case:
     severity: warn
-    message: "Schema name should be CamelCase in {{path}}"
+    message: "Schema name should be UpperCamelCase in {{path}}"
     given: >-
       $.components.schemas[*]~
     then:


### PR DESCRIPTION
Maak duidelijk dat het UpperCamelCase is om verwarring te voorkomen met lowerCamelCase.