### PR TITLE
Beheer: voeg expliciete PDF versie toe

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -104,6 +104,10 @@ function processRuleBlocks(config, document) {
 }
 
 globalThis.respecConfig = {
+  alternateFormats: [ {
+        "label" : "pdf",
+        "uri" : "api-adr-2.1.0.pdf"
+      } ],
   authors: [ 
       { 
         "company" : "Het Kadaster",


### PR DESCRIPTION
Het release script gebruikt al de nieuwe notatie, maar de config had die niet meer. In de vorige PR had ik die niet moeten verwijderen, maar in plaats daarvan vervangen met het goede formaat.