### PR TITLE
Beheer: voeg testcase toe voor missende version header

### DIFF
--- a/linter/testcases/version-header-missing/expected-output.txt
+++ b/linter/testcases/version-header-missing/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/version-header-missing/openapi.json
+ 40:35  error  nlgov:missing-version-header  Return the full version number in a response header  paths./openapi.json.get.responses[200].headers
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/version-header-missing/openapi.json
+++ b/linter/testcases/version-header-missing/openapi.json
@@ -1,0 +1,73 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Deze testcase miste nog. Hiermee zorgen we ervoor dat het duidelijk is waarom `nlgov:missing-version-header` als aparte regel bestaat, omdat anders OpenAPI specificaties zonder de header ook goedgekeurd zouden worden.