### PR TITLE
Beheer: start met spectral tests zonder build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
     uses: Logius-standaarden/Automatisering/.github/workflows/publish.yml@main
     secrets: inherit
   spectral_linter:
-    needs: build
     name: Spectral linter test cases
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Dit maakt meer gebruik van parallelisatie, omdat de build niet nodig is voor het draaien van Spectral tests.