### PR TITLE
Voeg signing en encryption modules toe als normatief

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -109,15 +109,19 @@ loadRespecWithConfiguration({
   localBiblio: {
     "ADR-encryption": {
       authors: ["P. Haasnoot"],
-      href: "https://gitdocumentatie.logius.nl/publicatie/api/mod-encryption/",
+      href: "https://logius-standaarden.github.io/API-mod-encryption/",
       publisher: "Logius",
-      title: "API Design Rules Module: Encryption"
+      title: "API Design Rules Module: Encryption",
+      // TODO: verwijder voor publicatie
+      status: "Draft",
     },
     "ADR-signing": {
       authors: ["P. Haasnoot"],
-      href: "https://gitdocumentatie.logius.nl/publicatie/api/mod-signing/",
+      href: "https://logius-standaarden.github.io/API-mod-signing/",
       publisher: "Logius",
-      title: "API Design Rules Module: Signing"
+      title: "API Design Rules Module: Signing",
+      // TODO: verwijder voor publicatie
+      status: "Draft",
     },
   }
 });

--- a/js/config.mjs
+++ b/js/config.mjs
@@ -1,5 +1,6 @@
 import { processRuleBlocks } from "https://logius-standaarden.github.io/publicatie/respec/plugins/adr.mjs";
 import { loadRespecWithConfiguration } from "https://logius-standaarden.github.io/publicatie/respec/organisation-config.mjs";
+import { generateMermaidFigures } from "https://logius-standaarden.github.io/publicatie/respec/plugins/mermaid.mjs";
 
 async function initializeHighlightJSYaml() {
   //this is the function you call in 'preProcess', to load the highlighter
@@ -103,5 +104,20 @@ loadRespecWithConfiguration({
   pluralize: true,
 
   preProcess: [initializeHighlightJSYaml, fetchSpectralConfiguration],
-  postProcess: [highlightSpectralCode, (config, document, utils) => processRuleBlocks(config, document, utils, spectralConfiguration)],
+  postProcess: [generateMermaidFigures, highlightSpectralCode, (config, document, utils) => processRuleBlocks(config, document, utils, spectralConfiguration)],
+
+  localBiblio: {
+    "ADR-encryption": {
+      authors: ["P. Haasnoot"],
+      href: "https://gitdocumentatie.logius.nl/publicatie/api/mod-encryption/",
+      publisher: "Logius",
+      title: "API Design Rules Module: Encryption"
+    },
+    "ADR-signing": {
+      authors: ["P. Haasnoot"],
+      href: "https://gitdocumentatie.logius.nl/publicatie/api/mod-signing/",
+      publisher: "Logius",
+      title: "API Design Rules Module: Signing"
+    },
+  }
 });

--- a/media/signing-in-combination-with-encryption.mermaid
+++ b/media/signing-in-combination-with-encryption.mermaid
@@ -1,0 +1,33 @@
+graph TD;
+    Request--"JSON(payload)"-->SignA;
+    SignA--"JWE(JWS(JSON(payload)))"-->SignB;
+    SignB--"JSON(payload)"-->Proc;
+    Proc--"JSON(payload)"-->SignC;
+    SignC--"JWS(JWE(JSON(payload)))"-->SignD;
+    SignD--"JSON(payload)"-->Response;
+
+
+    direction TB
+    subgraph Service Provider
+    direction TB
+    SignB("Decrypt with Provider private key</br
+    -----------------------</br>
+    Verify signature with Requester public key")
+    Proc(Process Request)
+    SignC("Sign with Provider private key </br>
+    -----------------------</br>
+    Encrypt with Requester public key")
+
+    end
+    subgraph Service Requester
+    direction TB
+    Request:::sc
+    SignA("Sign with Requester private key</br>
+    -----------------------</br>
+    Encrypt with Provider public key")
+    SignD("Decrypt with Requester private key </br>
+    -----------------------</br>
+    Verify signature with Provider public key")
+    classDef sc fill:#f96
+    Response:::sc
+    end

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -927,16 +927,17 @@ Services (potentially) including script code (e.g. JavaScript) in their response
 
 * Ensure the intended Content-Type headers are sent in the response, matching the body content, e.g. `application/json` and not `application/javascript`.
 
-## Geospatial
+## Normative modules
 
-Geospatial data refers to information that is associated with a physical location on Earth, often expressed by its 2D/3D coordinates.
+The following modules are normative for all REST API's.
 
-<div class="rule" id="/core/geospatial" data-type="functional">
+<div class="rule" id="/core/modules/geospatial" data-type="functional">
   <p class="rulelab">Apply the geospatial module for geospatial data</p>
   <dl>
     <dt>Statement</dt>
     <dd>
-       The [[[ADR-GEO]]] version 1.0.x MUST be applied when providing geospatial data or functionality.
+       <p>The [[[ADR-GEO]]] version 1.0.x MUST be applied when providing geospatial data or functionality.
+       <p class="note">Geospatial data refers to information that is associated with a physical location on Earth, often expressed by its 2D/3D coordinates.
     </dd>
     <dt>Rationale</dt>
     <dd>
@@ -949,3 +950,53 @@ Geospatial data refers to information that is associated with a physical locatio
     </dd>
   </dl>
 </div>
+
+<div class="rule" id="/core/modules/signing" data-type="functional">
+  <p class="rulelab">Apply the signing module for signing payloads</p>
+  <dl>
+    <dt>Statement</dt>
+    <dd>
+       <p>The [[[ADR-signing]]] version 1.0.x MUST be applied when signing payloads.
+       <p class="note">This rule does not dictate signing.
+       Instead, it only applies in situations where there is a need for assurance of end to end message integrity and authenticity between client application and server application.
+       In those situations, [[[ADR-signing]]] specifies how to sign.
+    </dd>
+    <dt>Rationale</dt>
+    <dd>
+      The [[[ADR-signing]]] formalizes as set of rules regarding:
+      <ol>
+         <li>How to sign data in request and response payloads.</li>
+         <li>Which header to specify the signature.</li>
+      </ol>
+    </dd>
+  </dl>
+</div>
+
+<div class="rule" id="/core/modules/encryption" data-type="functional">
+  <p class="rulelab">Apply the encryption module for encrypting payloads</p>
+  <dl>
+    <dt>Statement</dt>
+    <dd>
+       <p>The [[[ADR-encryption]]] version 1.0.x MUST be applied when encrypting payloads.
+       <p class="note">This rule does not dictate encryption.
+       Instead, it only applies in situations where there is a need for end to end message payload confidentiality between client application and server application.
+       In those situations, [[[ADR-encryption]]] specifies how to encrypt.
+    </dd>
+    <dt>Rationale</dt>
+    <dd>
+      The [[[ADR-encryption]]] formalizes as set of rules regarding:
+      <ol>
+         <li>How to encrypt data in request and response payloads.</li>
+         <li>The flow of operations between client and server.</li>
+      </ol>
+    </dd>
+  </dl>
+</div>
+
+If both the signing and encryption modules apply, use the following flow of operations:
+
+<figure>
+   <div class="mermaid" data-figure-name="signing-in-combination-with-encryption.mermaid">
+   </div>
+   <figcaption>Signing in combination with encryption</figcaption>
+</figure>


### PR DESCRIPTION
Hiermee worden ze officieel vastgesteld als normatieve modules voor alle REST API's. Op dit moment zijn ze enkel normatief binnen het REST API profiel van Digikoppeling. De modules zijn al vastgesteld bij het kennisplatform en als onderdeel van Digikoppeling, maar niet als losstaande documenten.