### PR TITLE
DELETE hetzelfde behandelen als GET voor 400 bad request

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -216,10 +216,10 @@ rules:
   #/core/error-handling/invalid-input
   nlgov:problem-invalid-input:
     severity: error
-    message: "GET endpoints that have parameters and all other endpoints must be able to return a 400 response"
+    message: "GET or DELETE endpoints that have parameters and all other endpoints must be able to return a 400 response"
     given:
-      - $.paths..[?( @property.match(/get/) && @.parameters && @.parameters.length > 0 )]
-      - $.paths..[?( @property.match(/(put)|(post)|(delete)|(patch)/))]
+      - $.paths..[?( @property.match(/(get)|(delete)/) && @.parameters && @.parameters.length > 0 )]
+      - $.paths..[?( @property.match(/(put)|(post)|(patch)/))]
     then:
       function: schema
       functionOptions:


### PR DESCRIPTION
Deze rule geldt alleen voor `GET` indien er query parameters meegestuurd worden (die invalid kunnen zijn). Dit zou m.i. hetzelfde moeten werken voor `DELETE`; hier worden ook geen body parameters meegestuurd.