### PR TITLE
Voeg regel toe over het documenteren van server URLs

### DIFF
--- a/linter/spectral.yml
+++ b/linter/spectral.yml
@@ -172,8 +172,8 @@ rules:
           char: ""
 
   nlgov:servers-use-https:
-    severity: warn
-    message: "Server URL {{value}} {{error}}."
+    severity: error
+    message: "Server URL {{value}} must start with https:// instead of http://."
     given:
       - $.servers[*]
       - $.paths..servers[*]
@@ -181,7 +181,46 @@ rules:
       field: url
       function: pattern
       functionOptions:
-        match: ^https://.*
+        notMatch: ^http://.*
+
+  nlgov:servers-at-most-one-relative:
+    severity: error
+    message: "At most one relative URL may be specified as server."
+    given:
+      - $.servers
+      - $.paths..servers
+    then:
+      function: schema
+      functionOptions:
+        dialect: draft2020-12
+        schema:
+          type: array
+          contains:
+            type: object
+            properties:
+              url:
+                pattern: ^(?!https:).+
+          minContains: 0
+          maxContains: 1
+
+  nlgov:servers-at-least-one-absolute:
+    severity: error
+    message: "At least one absolute URL must be specified as server."
+    given:
+      - $.servers
+      - $.paths..servers
+    then:
+      function: schema
+      functionOptions:
+        dialect: draft2020-12
+        schema:
+          type: array
+          contains:
+            type: object
+            properties:
+              url:
+                pattern: ^https://.*
+          minContains: 1
 
   nlgov:use-problem-schema:
     severity: warn

--- a/linter/testcases/servers-empty/expected-output.txt
+++ b/linter/testcases/servers-empty/expected-output.txt
@@ -1,5 +1,6 @@
 
 /testcases/servers-empty/openapi.json
- 13:15  error  oas3-api-servers  OpenAPI "servers" must be present and non-empty array.  servers
+ 13:15  error  nlgov:servers-at-least-one-absolute  At least one absolute URL must be specified as server.  servers
+ 13:15  error  oas3-api-servers                     OpenAPI "servers" must be present and non-empty array.  servers
 
-✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)
+✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/servers-no-absolute/expected-output.txt
+++ b/linter/testcases/servers-no-absolute/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/servers-no-absolute/openapi.json
+ 13:15  error  nlgov:servers-at-least-one-absolute  At least one absolute URL must be specified as server.  servers
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/servers-no-absolute/openapi.json
+++ b/linter/testcases/servers-no-absolute/openapi.json
@@ -1,0 +1,81 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "/api/v1",
+            "description": "API location on the origin that the openapi.json is served"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/servers-no-https/expected-output.txt
+++ b/linter/testcases/servers-no-https/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/servers-no-https/openapi.json
+ 15:20  error  nlgov:servers-use-https  Server URL http://production.example.com/api/v1 must start with https:// instead of http://.  servers[0].url
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/servers-no-https/openapi.json
+++ b/linter/testcases/servers-no-https/openapi.json
@@ -1,0 +1,85 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://production.example.com/api/v1",
+            "description": "Production server"
+        },
+        {
+            "url": "https://staging.example.com/api/v1",
+            "description": "Pre-production server"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/servers-relative-one/expected-output.txt
+++ b/linter/testcases/servers-relative-one/expected-output.txt
@@ -1,0 +1,1 @@
+No results with a severity of 'error' found!

--- a/linter/testcases/servers-relative-one/openapi.json
+++ b/linter/testcases/servers-relative-one/openapi.json
@@ -1,0 +1,89 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://production.example.com/api/v1",
+            "description": "Production server"
+        },
+        {
+            "url": "https://staging.example.com/api/v1",
+            "description": "Pre-production server"
+        },
+        {
+            "url": "/api/v1",
+            "description": "API location on the origin that the openapi.json is served"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/linter/testcases/servers-relative-two/expected-output.txt
+++ b/linter/testcases/servers-relative-two/expected-output.txt
@@ -1,0 +1,5 @@
+
+/testcases/servers-relative-two/openapi.json
+ 13:15  error  nlgov:servers-at-most-one-relative  At most one relative URL may be specified as server.  servers
+
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/servers-relative-two/openapi.json
+++ b/linter/testcases/servers-relative-two/openapi.json
@@ -1,0 +1,93 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://production.example.com/api/v1",
+            "description": "Production server"
+        },
+        {
+            "url": "https://staging.example.com/api/v1",
+            "description": "Pre-production server"
+        },
+        {
+            "url": "/api/v1",
+            "description": "API location on the origin that the openapi.json is served"
+        },
+        {
+            "url": "/api/v2",
+            "description": "API location on the origin that the openapi.json is served"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -534,6 +534,43 @@ An API is as good as the accompanying documentation. The documentation has to be
    </dl>
 </div>
 
+<div class="rule" id="/core/doc-openapi-servers" data-type="technical">
+  <p class="rulelab">Document server information</p>
+  <dl>
+      <dt>Statement</dt>
+      <dd>
+         OpenAPI definition document MUST include at least one Server object in <a href="https://spec.openapis.org/oas/v3.0.1.html#server-object"><code>servers</code></a>.
+         One or more Server objects MUST have a <code>url</code> which is an absolute URL.
+         At most one Server object MAY have a <url>url</code> which is a relative URL.
+      </dd>
+      <dt>Rationale</dt>
+      <dd>
+         The OpenAPI Specification (OAS) [[OPENAPIS]] can include information about servers which serve this API. It can list different environments, such as production and pre-production. If desired, a relative URL can be used to denote where an API resides, regardless of origin. However, only one relative URL may be present to avoid ambiguation for consumers which relative URL is applicable for the current origin.
+         <aside class="example">
+            <pre><code class="json">[{
+  "url": "https://production.example.com/api/v1",
+  "description": "Production server"
+},
+{
+  "url": "https://staging.example.com/api/v1",
+  "description": "Pre-production server"
+},
+{
+  "url": "/api/v1",
+  "description": "API location on the origin that the openapi.json is served"
+}]</code></pre>
+         </aside>
+      </dd>
+      <dt>How to test</dt>
+      <dd>
+        <ul>
+          <li>Step 1: Parse the OpenAPI Description to confirm the <code>servers</code> list is present.</li>
+          <li>Step 2: The list contains at least one object with an absolute URL</li>
+          <li>Step 3: The list contains at most one object with a relative URL</li>
+      </dd>
+   </dl>
+</div>
+
 <span id="api-17"></span>
 <div class="rule" id="/core/doc-language" data-type="functional">
   <p class="rulelab">Publish documentation in Dutch unless there is existing documentation in English</p>

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -547,18 +547,22 @@ An API is as good as the accompanying documentation. The documentation has to be
       <dd>
          The OpenAPI Specification (OAS) [[OPENAPIS]] can include information about servers which serve this API. It can list different environments, such as production and pre-production. If desired, a relative URL can be used to denote where an API resides, regardless of origin. However, only one relative URL may be present to avoid ambiguation for consumers which relative URL is applicable for the current origin.
          <aside class="example">
-            <pre><code class="json">[{
-  "url": "https://production.example.com/api/v1",
-  "description": "Production server"
-},
-{
-  "url": "https://staging.example.com/api/v1",
-  "description": "Pre-production server"
-},
-{
-  "url": "/api/v1",
-  "description": "API location on the origin that the openapi.json is served"
-}]</code></pre>
+            <pre><code class="json">{
+  "servers": [
+    {
+      "url": "https://production.example.com/api/v1",
+      "description": "Production server"
+    },
+    {
+      "url": "https://staging.example.com/api/v1",
+      "description": "Pre-production server"
+    },
+    {
+      "url": "/api/v1",
+      "description": "API location on the origin that the openapi.json is served"
+    }
+  ]
+}</code></pre>
          </aside>
       </dd>
       <dt>How to test</dt>


### PR DESCRIPTION
Hiermee maken we een eerste stap in het enforceren
 van informatie over servers. Tevens maken we hiermee
 duidelijk dat een relatieve URL is toegestaan, echter
 moet er altijd minstens 1 absolute URL zijn.

Part of #208
Fixes #290