### PR TITLE
Beheer: verplaats linter configuratie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     uses: Logius-standaarden/Automatisering/.github/workflows/publish.yml@main
     secrets: inherit
   spectral_linter:
-    name: Spectral linter test cases
+    name: Linter test cases
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/examples/run-spectral-linter.sh
+++ b/examples/run-spectral-linter.sh
@@ -7,4 +7,4 @@ if ! [ -f "$1" ]; then
   exit 1
 fi
 
-spectral lint -r $CURRENT_DIRECTORY/../linter/spectral.yml $1
+spectral lint -r $CURRENT_DIRECTORY/../media/linter.yml $1

--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
   <section data-include="sections/glossary.md" data-include-format="markdown">
   </section>
   <section class="appendix informative">
-    <h2>Spectral linter configuration</h2>
-    <details class="spectral-yaml">
+    <h2>Linter configuration</h2>
+    <details class="linter-yaml">
       <pre><code></code></pre>
     </details>
   </section>

--- a/js/config.mjs
+++ b/js/config.mjs
@@ -22,20 +22,21 @@ async function initializeHighlightJSYaml() {
   });
 }
 
-let spectralConfiguration;
-async function fetchSpectralConfiguration() {
-  const spectralResponse = await fetch('linter/spectral.yml');
-  spectralConfiguration = await spectralResponse.text();
+const LINTER_CONFIGURATION_PATH = 'media/linter.yml';
+let linterConfiguration;
+async function fetchLinterConfiguration() {
+  const linterResponse = await fetch(LINTER_CONFIGURATION_PATH);
+  linterConfiguration = await linterResponse.text();
 }
 
-async function highlightSpectralCode(config, document) {
+async function highlightLinterCode(config, document) {
   //this is the function you call in 'postProcess', to load the highlighter
   const worker = await new Promise(resolve => {
     require(["core/worker"], ({ worker }) => resolve(worker));
   });
 
   const action = "highlight";
-  const code = spectralConfiguration;
+  const code = linterConfiguration;
   const lang = "yaml";
   worker.postMessage({ action, code, languages: [lang] });
   return new Promise(resolve => {
@@ -44,8 +45,12 @@ async function highlightSpectralCode(config, document) {
       if (responseAction === action && responseLang === lang) {
         worker.removeEventListener("message", listener);
 
-        const codeElement = document.querySelector('.spectral-yaml code');
+        const codeElement = document.querySelector('.linter-yaml code');
         codeElement.innerHTML = data.value;
+        const linkToConfiguration = document.createElement('div');
+        linkToConfiguration.innerHTML = `Open the above details to inspect the linter configuration. You can also <a href="${LINTER_CONFIGURATION_PATH}">open the configuration file in separate tab</a>`
+        linkToConfiguration.style.marginTop = '1em';
+        document.querySelector('.linter-yaml').after(linkToConfiguration);
         resolve();
       }
     });
@@ -103,8 +108,8 @@ loadRespecWithConfiguration({
   specType: "ST",
   pluralize: true,
 
-  preProcess: [initializeHighlightJSYaml, fetchSpectralConfiguration],
-  postProcess: [generateMermaidFigures, highlightSpectralCode, (config, document, utils) => processRuleBlocks(config, document, utils, spectralConfiguration)],
+  preProcess: [initializeHighlightJSYaml, fetchLinterConfiguration],
+  postProcess: [generateMermaidFigures, highlightLinterCode, (config, document, utils) => processRuleBlocks(config, document, utils, linterConfiguration)],
 
   localBiblio: {
     "ADR-encryption": {

--- a/linter/run-linter-tests.mjs
+++ b/linter/run-linter-tests.mjs
@@ -11,10 +11,10 @@ const readFile = utils.promisify(fs.readFile);
 const readdir = utils.promisify(fs.readdir);
 const writeFile = utils.promisify(fs.writeFile);
 
-const SPECTRAL_RULESET_LOCATION = path.join(__dirname, 'spectral.yml');
+const LINTER_RULESET_LOCATION = path.join(__dirname, '..', 'media', 'linter.yml');
 
 function computeTestCommand(apiLocation) {
-    return `spectral lint -r ${SPECTRAL_RULESET_LOCATION} ${apiLocation}/openapi.json || true`
+    return `spectral lint -r ${LINTER_RULESET_LOCATION} ${apiLocation}/openapi.json || true`
 }
 
 function removeProcessDir(output) {

--- a/media/linter.yml
+++ b/media/linter.yml
@@ -13,8 +13,8 @@
 #
 # ```
 # npm install -g @stoplight/spectral-cli
-# curl -L https://static.developer.overheid.nl/adr/ruleset.yaml > .spectral.yml
-# spectral lint -r .spectral.yml $OAS_URL_OR_FILE
+# curl -L https://static.developer.overheid.nl/adr/ruleset.yaml > .linter.yml
+# spectral lint -r .linter.yml $OAS_URL_OR_FILE
 # ```
 
 extends: spectral:oas


### PR DESCRIPTION
Hiermee bereiken we twee doelen:
1. De naamgeving is niet gelimiteerd aan Spectral, omdat ook andere tooling deze configuratie kan gebruiken
2. Omdat het nu in `media/` staat, publiceren we deze configuratie nu ook op een aparte plek. Hierdoor is het mogelijk om voor andere tooling om automatisch het bestand te pakken, in plaats van die uit een bijlage van het standaarddocument te halen

Uiteindelijk zorgen we ervoor dat tooling zoals developer.overheid.nl nu naar deze configuratie kunnen verwijzen en ook automatisch up-to-date zijn met wijzigingen die we aanbrengen.

Fixes #254 