### PR TITLE
Beheer: fix logius.nl links

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -83,17 +83,17 @@ loadRespecWithConfiguration({
       },
       { 
         "company" : "Logius",
-        "companyURL" : "https://www.logius.nl",
+        "companyURL" : "https://logius.nl",
         "name" : "Alexander Green"
       },
       { 
         "company" : "Logius",
-        "companyURL" : "https://www.logius.nl",
+        "companyURL" : "https://logius.nl",
         "name" : "Martin van der Plas"
       },
       { 
         "company" : "Logius",
-        "companyURL" : "https://www.logius.nl",
+        "companyURL" : "https://logius.nl",
         "name" : "Tim van der Lippe"
       }
     ],


### PR DESCRIPTION
Om consistent te zijn met de andere standaarden moet de `www.` weg.