### PR TITLE
Beheer: fix links naar API strategie Kennisplatform API's (#320)

### DIFF
--- a/sections/abstract.md
+++ b/sections/abstract.md
@@ -1,3 +1,3 @@
 This document contains a normative standard for designing APIs in the Dutch Public Sector.
 The Governance of this standard is described by the [API-Standaarden beheermodel](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/) published by Logius.
-This document is part of the *Nederlandse API Strategie*, which consists of [a set of documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
+This document is part of the *Nederlandse API Strategie*, which consists of [a set of documents](https://developer.overheid.nl/communities/kennisplatform-apis/#api-strategie).

--- a/sections/introduction.md
+++ b/sections/introduction.md
@@ -18,7 +18,7 @@ Despite the fact that two authors are mentioned in the list of authors, this doc
 
 This document is part of the *Nederlandse API Strategie*.
 
-The Nederlandse API Strategie consists of [a set of distinct documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
+The Nederlandse API Strategie consists of [a set of distinct documents](https://developer.overheid.nl/communities/kennisplatform-apis/#api-strategie).
 
 | Status           | Description & Link                                           |
 | ---------------- | ------------------------------------------------------------ |


### PR DESCRIPTION
Dit is een backport van #320 naar `main` om de links te fixen.