### PR TITLE
Gebruik enkel specifieke Spectral OAS rules

### DIFF
--- a/linter/testcases/paths-kebab-slashes/expected-output.txt
+++ b/linter/testcases/paths-kebab-slashes/expected-output.txt
@@ -1,6 +1,6 @@
 
 /testcases/paths-kebab-slashes/openapi.json
-  96:26  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
- 154:37  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
+  96:26  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
+ 154:37  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
 
-✖ 2 problems (0 errors, 2 warnings, 0 infos, 0 hints)
+✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/paths-kebab-zoek-uitzondering/openapi.json
- 125:19  warning  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
+ 125:19  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
 
-✖ 1 problem (0 errors, 1 warning, 0 infos, 0 hints)
+✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -17,10 +17,22 @@
 # spectral lint -r .linter.yaml $OAS_URL_OR_FILE
 # ```
 
-extends: spectral:oas
+extends:
+  - ["spectral:oas", "off"] # extend spectral:oas maar zet standaard alle regels uit
 
 rules:
+  #/core/publish-openapi (deze error-rules valideren of OAS valid is)
+  oas3-schema: error
+  operation-operationId-unique: error
+  path-params: error
+  openapi-tags-uniqueness: error
+  oas3-valid-media-example: error
+  oas3-valid-schema-example: error
+  oas3-server-variables: error
   oas3-api-servers: error
+
+  #/core/no-trailing-slash
+  path-keys-no-trailing-slash: error
 
   #/core/doc-openapi
   nlgov:openapi3:


### PR DESCRIPTION
Hiermee zorgen we ervoor dat we enkel regels aanzetten die ook relevant zijn voor de API Design Rules. Tevens zetten we die regels op error in plaats van warning, omdat ze ook verplicht zijn. Als laatste zorgt dit ervoor dat we ook netjes de publish OpenAPI design rule kunnen linken aan regels.

Fixes #315