### PR TITLE
Beheer: voeg linter regel toe voor invalid-input

### DIFF
--- a/linter/testcases/error-type-invalid-input/expected-output.txt
+++ b/linter/testcases/error-type-invalid-input/expected-output.txt
@@ -1,0 +1,7 @@
+
+/testcases/error-type-invalid-input/openapi.json
+ 119:29  error  nlgov:problem-invalid-input  GET and DELETE endpoints that have parameters, and all other endpoints must be able to return a 400 response  paths./invalid-response-vereist.get.responses
+ 157:29  error  nlgov:problem-invalid-input  GET and DELETE endpoints that have parameters, and all other endpoints must be able to return a 400 response  paths./invalid-response-vereist.put.responses
+ 195:29  error  nlgov:problem-invalid-input  GET and DELETE endpoints that have parameters, and all other endpoints must be able to return a 400 response  paths./invalid-response-vereist.post.responses
+
+✖ 3 problems (3 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/error-type-invalid-input/openapi.json
+++ b/linter/testcases/error-type-invalid-input/openapi.json
@@ -25,7 +25,7 @@
             "name": "openapi"
         },
         {
-            "name": "zoek"
+            "name": "resource"
         }
     ],
     "paths": {
@@ -55,134 +55,6 @@
                                 }
                             }
                         }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
-            }
-        },
-        "/organisaties/_zoek": {
-            "get": {
-                "tags": [
-                    "zoek"
-                ],
-                "description": "Organisatie zoek operatie",
-                "operationId": "organisatieZoek",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
-            }
-        },
-        "/_zoek": {
-            "get": {
-                "tags": [
-                    "zoek"
-                ],
-                "description": "Globale zoekoperatie",
-                "operationId": "globalZoek",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
-            }
-        },
-        "/_zoek/": {
-            "get": {
-                "tags": [
-                    "zoek"
-                ],
-                "description": "Globale zoekoperatie met trailing",
-                "operationId": "globalZoekMetTrailing",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "default": []
-                    }
-                ]
-            }
-        },
-        "/organisaties/{id}/nested/_zoek": {
-            "get": {
-                "tags": [
-                    "zoek"
-                ],
-                "description": "Met variabele nested en zoek",
-                "operationId": "getWithVariableNestedEnZoek",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "De variabele",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "style": "simple",
-                        "explode": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {
-                            "API-Version": {
-                                "description": "De huidige versie van de applicatie",
-                                "style": "simple",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     },
                     "400": {
                         "description": "OK",
@@ -195,21 +67,140 @@
                                         "title": { "type": "string" },
                                         "detail": { "type": "string" },
                                         "errors": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "in": { "type": "string" },
-                                                    "location": { "type": "string" },
-                                                    "code": { "type": "string" },
-                                                    "detail": { "type": "string" },
-                                                    "index": { "type": "number" }
-                                                }
+                                            "type": "object",
+                                            "properties": {
+                                                "in": { "type": "string" },
+                                                "location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "pointer": { "type": "string" },
+                                                        "name": { "type": "string" },
+                                                        "index": { "type": "integer" }
+                                                    }
+                                                },
+                                                "code": { "type": "string" },
+                                                "detail": { "type": "string" }
                                             }
                                         }
                                     },
                                     "required": ["status", "title", "detail", "errors"],
                                     "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/invalid-response-vereist": {
+            "get": {
+                "tags": [
+                    "resource"
+                ],
+                "description": "Resource",
+                "operationId": "getPropertiesCorrect",
+                "parameters": [
+                    {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Schakelaar om details van gekoppelde organisaties (subOIN of OINhouder) op te vragen (default false = geen details)",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "resource"
+                ],
+                "description": "Resource",
+                "operationId": "putPropertiesCorrect",
+                "parameters": [
+                    {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Schakelaar om details van gekoppelde organisaties (subOIN of OINhouder) op te vragen (default false = geen details)",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "resource"
+                ],
+                "description": "Resource",
+                "operationId": "postPropertiesCorrect",
+                "parameters": [
+                    {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Schakelaar om details van gekoppelde organisaties (subOIN of OINhouder) op te vragen (default false = geen details)",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }

--- a/linter/testcases/paths-kebab-variables/openapi.json
+++ b/linter/testcases/paths-kebab-variables/openapi.json
@@ -55,6 +55,36 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "OK",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": { "type": "integer" },
+                                        "title": { "type": "string" },
+                                        "detail": { "type": "string" },
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "in": { "type": "string" },
+                                                    "location": { "type": "string" },
+                                                    "code": { "type": "string" },
+                                                    "detail": { "type": "string" },
+                                                    "index": { "type": "number" }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": ["status", "title", "detail", "errors"],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -93,6 +123,36 @@
                                 "style": "simple",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "OK",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": { "type": "integer" },
+                                        "title": { "type": "string" },
+                                        "detail": { "type": "string" },
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "in": { "type": "string" },
+                                                    "location": { "type": "string" },
+                                                    "code": { "type": "string" },
+                                                    "detail": { "type": "string" },
+                                                    "index": { "type": "number" }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": ["status", "title", "detail", "errors"],
+                                    "additionalProperties": false
                                 }
                             }
                         }
@@ -137,6 +197,36 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "OK",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": { "type": "integer" },
+                                        "title": { "type": "string" },
+                                        "detail": { "type": "string" },
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "in": { "type": "string" },
+                                                    "location": { "type": "string" },
+                                                    "code": { "type": "string" },
+                                                    "detail": { "type": "string" },
+                                                    "index": { "type": "number" }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": ["status", "title", "detail", "errors"],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -175,6 +265,36 @@
                                 "style": "simple",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "OK",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": { "type": "integer" },
+                                        "title": { "type": "string" },
+                                        "detail": { "type": "string" },
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "in": { "type": "string" },
+                                                    "location": { "type": "string" },
+                                                    "code": { "type": "string" },
+                                                    "detail": { "type": "string" },
+                                                    "index": { "type": "number" }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": ["status", "title", "detail", "errors"],
+                                    "additionalProperties": false
                                 }
                             }
                         }

--- a/linter/testcases/query-keys-camel-case/openapi.json
+++ b/linter/testcases/query-keys-camel-case/openapi.json
@@ -127,6 +127,36 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "OK",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": { "type": "integer" },
+                                        "title": { "type": "string" },
+                                        "detail": { "type": "string" },
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "in": { "type": "string" },
+                                                    "location": { "type": "string" },
+                                                    "code": { "type": "string" },
+                                                    "detail": { "type": "string" },
+                                                    "index": { "type": "number" }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": ["status", "title", "detail", "errors"],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [

--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -134,7 +134,7 @@ rules:
   nlgov:paths-kebab-case:
     severity: error
     message: "{{property}} is not kebab-case."
-    given: $.paths[?(@property && !@property.match(/\/openapi\.json/))]~
+    given: $.paths[?(@property && !@property.match(/\/openapi\.(json)|(yaml)/))]~
     then:
       function: pattern
       functionOptions:
@@ -212,6 +212,24 @@ rules:
               - status
               - title
               - detail
+
+  #/core/error-handling/invalid-input
+  nlgov:problem-invalid-input:
+    severity: error
+    message: "GET and DELETE endpoints that have parameters, and all other endpoints must be able to return a 400 response"
+    given:
+      - $.paths..[?( @property.match(/(get)|(delete)/) && @.parameters && @.parameters.length > 0 )]
+      - $.paths..[?( @property.match(/(put)|(post)|(patch)/))]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            responses:
+              type: object
+              required:
+              - "400"
 
   nlgov:property-casing:
     severity: warn


### PR DESCRIPTION
Die is per abuis verwijderd in 616fe47f16bf4536bf54b398c2a3d96f9d407b3b terwijl die er wel in had gemoeten.

Tevens fixt het een klein issue waar `openapi.yaml` niet goed werden genegeerd, zoals we al deden voor `openapi.json`.