### PR TITLE
Voeg regel toe voor informatie over talen

### DIFF
--- a/linter/testcases/language-code/expected-output.txt
+++ b/linter/testcases/language-code/expected-output.txt
@@ -1,0 +1,17 @@
+
+/testcases/language-code/openapi.json
+  92:52  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.language
+  95:65  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.thoroughfare_language
+  98:70  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.railName_localNameLanguage
+ 101:48  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.taal
+ 104:59  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.organisatieTaal
+ 107:60  error  nlgov:specify-format-for-language-code  Any field that represents a language must set 'format' to 'language'       paths./resources-with-language-incorrect.get.responses[200].content.application/json.schema.properties.organisatie_taal
+ 127:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.language.format
+ 131:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.thoroughfare_language.format
+ 135:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.railName_localNameLanguage.format
+ 139:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.taal.format
+ 143:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.organisatieTaal.format
+ 147:55  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  paths./resources-with-language-incorrect.get.responses[200].content.application/json+verkeerd-format.schema.properties.organisatie_taal.format
+ 236:27  error  nlgov:use-language-code                 Field represents a language and therefore must set 'format' to 'language'  components.schemas.LanguageIncorrect.format
+
+✖ 13 problems (13 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/language-code/openapi.json
+++ b/linter/testcases/language-code/openapi.json
@@ -1,0 +1,256 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Baseline",
+        "description": "Deze OpenAPI specification bevat het minimale om aan alle regels te voldoen.",
+        "contact": {
+            "name": "Beheerder",
+            "url": "https://www.example.com",
+            "email": "mail@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://example.com/api/v1"
+        }
+    ],
+    "security": [
+        {
+            "default": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "openapi"
+        },
+        {
+            "name": "language"
+        }
+    ],
+    "paths": {
+        "/openapi.json": {
+            "get": {
+                "tags": [
+                    "openapi"
+                ],
+                "description": "OpenAPI document",
+                "operationId": "getOpenapiJSON",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "access-control-allow-origin": {
+                                "description": "Alle origins mogen bij deze resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/resources-with-language-incorrect": {
+            "get": {
+                "tags": [
+                    "language"
+                ],
+                "description": "Resources with language incorrect",
+                "operationId": "getLanguageIncorrect",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "language": {
+                                            "type": "string"
+                                        },
+                                        "thoroughfare_language": {
+                                            "type": "string"
+                                        },
+                                        "railName_localNameLanguage": {
+                                            "type": "string"
+                                        },
+                                        "taal": {
+                                            "type": "string"
+                                        },
+                                        "organisatieTaal": {
+                                            "type": "string"
+                                        },
+                                        "organisatie_taal": {
+                                            "type": "string"
+                                        },
+                                        "meerdereTaal": {
+                                            "type": "string",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/LanguageIncorrect"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "application/json+verkeerd-format": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "language": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        },
+                                        "thoroughfare_language": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        },
+                                        "railName_localNameLanguage": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        },
+                                        "taal": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        },
+                                        "organisatieTaal": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        },
+                                        "organisatie_taal": {
+                                            "type": "string",
+                                            "format": "byte"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        },
+        "/resources-with-language-correct": {
+            "get": {
+                "tags": [
+                    "language"
+                ],
+                "description": "Resources with language correct",
+                "operationId": "getLanguagesCorrect",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "API-Version": {
+                                "description": "De huidige versie van de applicatie",
+                                "style": "simple",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "language": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "thoroughfare_language": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "railName_localNameLanguage": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "taal": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "organisatieTaal": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "organisatie_taal": {
+                                            "type": "string",
+                                            "format": "language"
+                                        },
+                                        "meerdereTaal": {
+                                            "type": "string",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/LanguageCorrect"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "default": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "LanguageIncorrect": {
+                "format": "byte",
+                "type": "string"
+            },
+            "LanguageCorrect": {
+                "format": "language",
+                "type": "string"
+            }
+        },
+        "securitySchemes": {
+            "default": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://test.com",
+                        "scopes": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -282,6 +282,39 @@ rules:
       functionOptions:
         notMatch: "/^date-time$/"
 
+  #/core/lang-code
+  nlgov:specify-format-for-language-code:
+    severity: error
+    given:
+      - $..properties[taal,lang,language]
+      - $..properties[?(@property && @property.match(/((\w+T)|(_[tT]))aal/))]
+      - $..properties[?(@property && @property.match(/((\w+L)|(_[lL]))ang(uage)?/))]
+    message: "Any field that represents a language must set 'format' to 'language'"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          anyOf:
+            - required: ["format"]
+            - properties:
+                allOf:
+                  type: array
+                  items:
+                    required: ["format"]
+              required: ["allOf"]
+
+  nlgov:use-language-code:
+    severity: error
+    given:
+      - $..properties[taal,lang,language]..format
+      - $..properties[?(@property && @property.match(/((\w+T)|(_[tT]))aal/))]..format
+      - $..properties[?(@property && @property.match(/((\w+L)|(_[lL]))ang(uage)?/))]..format
+    message: "Field represents a language and therefore must set 'format' to 'language'"
+    then:
+      function: pattern
+      functionOptions:
+        match: "/^language$/"
+
   nlgov:semver:
     severity: error
     message: "Version {{value}} is not in semver format."

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -288,7 +288,7 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
             <li>Analyse all fields and if the field represents a language and ensure either one of the following options applies:
             <ul>
                <li>In case of singular localized information, ensure it is an object. It has two fields <code>"taal"</code> and <code>"waarde"</code> or it has two fields <code>"language"</code> and <code>"value"</code>.
-               <li>In case of multiple localized options, ensure it is an array. Either all objects have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects have two fields <code>"language"</code> and <code>"value"</code>.
+               <li>In case of multiple localized options, ensure it is an array consisting of objects. Either all objects have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects have two fields <code>"language"</code> and <code>"value"</code>.
             </ul>
             <li>Confirm each field <code>"taal"</code> or <code>"language"</code> has a value in [[RFC5646]] format.
          </ul>

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -243,7 +243,6 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </code></pre>
          </aside>
          <p>All fields in requests and responses containing multiple localized options MUST be an array of objects where all objects have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the localized string.
-         <p> 
          <aside class="example">
             The following example shows a response for a resource with multiple localized options in an API with Dutch as its interface language.
             <pre><code class="json">{
@@ -277,7 +276,7 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </code></pre>
          </aside>
          <p class="warning">[[?ISO3166-1]] concerns identifiers of countries and MUST NOT be used to denote languages, since countries and languages are not equivalent.
-         <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format match a language tag in [[RFC5646]] regardless of language subtag.
+         <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format matches a language tag in [[RFC5646]] regardless of language subtag.
       </dd>
       <dt>Rationale</dt>
       <dd>

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -215,15 +215,15 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </div>
 
 <div class="rule" id="/core/lang-code" data-type="technical">
-   <p class="rulelab">Use standard language codes and field names for multilingual content</p>
+   <p class="rulelab">Use standard language codes and field names for language content</p>
    <dl>
       <dt>Statement</dt>
       <dd>
-         <p>A resource containing localized information MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
-         All fields in requests and responses containing singular localized information MUST be an object with two fields (JSON) or tag with two subtags (XML). In it, <code>"taal"</code> (Dutch) or <code>"language"</code> (English) contains a value conforming [[RFC5646]] and <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) contains the localized string.
+         <p>A resource containing language content MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
+         All fields in requests and responses containing monolingual content MUST be an object with two fields (JSON) or tag with two subtags (XML). In it, <code>"taal"</code> (Dutch) or <code>"language"</code> (English) contains a value conforming [[RFC5646]] and <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) contains the lingual content.
          <p class="note">Use the <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">language subtag registry</a> maintained by IANA for possible language subtags.
          <aside class="example">
-            The following example shows a response for a resource with singular localized information in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
+            The following example shows a response for a resource with monolingual content in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
   "ondertitel": {
     "taal": "nl-NL",
@@ -233,7 +233,7 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </code></pre>
          </aside>
          <aside class="example">
-            The following example shows a response for a resource with singular localized information in an API with English as its <a href="#/core/interface-language">interface language</a>.
+            The following example shows a response for a resource with monolingual content in an API with English as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
   "subtitle": {
     "language": "nl-NL",
@@ -242,9 +242,9 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 }
 </code></pre>
          </aside>
-         <p>All fields in requests and responses containing multiple localized options MUST be an array of objects where all objects have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the localized string.
+         <p>All fields in requests and responses containing multilingual content MUST be an array of objects (JSON) or multiple children tags (XML). All elements either have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the lingual content.
          <aside class="example">
-            The following example shows a response for a resource with multiple localized options in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
+            The following example shows a response for a resource with multilingual content in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
   "ondertitel": [
      {
@@ -260,7 +260,7 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </code></pre>
          </aside>
          <aside class="example">
-            The following example shows a response for a resource with multiple localized options in an API with English as its <a href="#/core/interface-language">interface language</a>.
+            The following example shows a response for a resource with multilingual content in an API with English as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
   "subtitle": [
      {
@@ -287,8 +287,8 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
          <ul>
             <li>Analyse all fields and if the field represents a language and ensure either one of the following options applies:
             <ul>
-               <li>In case of singular localized information, ensure it is an object. It has two fields <code>"taal"</code> and <code>"waarde"</code> or it has two fields <code>"language"</code> and <code>"value"</code>.
-               <li>In case of multiple localized options, ensure it is an array consisting of objects. Either all objects have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects have two fields <code>"language"</code> and <code>"value"</code>.
+               <li>In case of monolingual content, ensure it is an object (JSON) or tag (XML). It has two fields <code>"taal"</code> and <code>"waarde"</code> or it has two fields <code>"language"</code> and <code>"value"</code>.
+               <li>In case of multilingual content, ensure it is an array consisting of objects (JSON) or multiple children tags (XML). Either all objects/children have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects/children have two fields <code>"language"</code> and <code>"value"</code>.
             </ul>
             <li>Confirm each field <code>"taal"</code> or <code>"language"</code> has a value in [[RFC5646]] format.
          </ul>

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -214,6 +214,89 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
    </dl>
 </div>
 
+<div class="rule" id="/core/lang-code" data-type="technical">
+   <p class="rulelab">Use standard language codes for localization</p>
+   <dl>
+      <dt>Statement</dt>
+      <dd>
+         <p>A resource containing localized information MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
+         All fields in requests and responses containing singular localized information MUST be an object with a field <code>"taal"</code> (Dutch) or <code>"language"</code> (English) with a value conforming [[RFC5646]] and a field <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) with the localized string.
+         <p class="note">Use the <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">language subtag registry</a> maintained by IANA for possible language subtags.
+         <aside class="example">
+            The following example shows a response for a resource with singular localized information in an API with Dutch as its interface language.
+            <pre><code class="json">{
+  "status": {
+    "taal": "nl-NL",
+    "waarde": "Goedgekeurd"
+  }
+}
+</code></pre>
+         </aside>
+         <aside class="example">
+            The following example shows a response for a resource with singular localized information in an API with English as its interface language.
+            <pre><code class="json">{
+  "status": {
+    "language": "nl-NL",
+    "value": "Goedgekeurd"
+  }
+}
+</code></pre>
+         </aside>
+         <p>All fields in requests and responses containing multiple localized options MUST be an array of objects where all objects have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the localized string.
+         <p> 
+         <aside class="example">
+            The following example shows a response for a resource with multiple localized options in an API with Dutch as its interface language.
+            <pre><code class="json">{
+  "status": [
+     {
+      "taal": "nl-NL",
+      "waarde": "Goedgekeurd"
+    },
+    {
+      "taal": "en-GB",
+      "waarde": "Accepted"
+    }
+  ]
+}
+</code></pre>
+         </aside>
+         <aside class="example">
+            The following example shows a response for a resource with multiple localized options in an API with English as its interface language.
+            <pre><code class="json">{
+  "status": [
+     {
+      "language": "nl-NL",
+      "value": "Goedgekeurd"
+     },
+     {
+       "language": "en-GB",
+       "value": "Accepted"
+     }
+  ]
+}
+</code></pre>
+         </aside>
+         <p class="warning">[[?ISO3166-1]] concerns identifiers of countries and MUST NOT be used to denote languages, since countries and languages are not equivalent.
+         <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format match a language tag in [[RFC5646]] regardless of language subtag.
+      </dd>
+      <dt>Rationale</dt>
+      <dd>
+         Standardized language codes removes ambiguity in language handling between systems, potentially present in separate regions with different (spoken) languages.
+      </dd>
+      <dt>How to test</dt>
+      <dd>
+         <ul>
+            <li>Analyse all fields and if the field represents a language and ensure either one of the following options applies:
+            <ul>
+               <li>In case of singular localized information, ensure it is an object. It has two fields <code>"taal"</code> and <code>"waarde"</code> or it has two fields <code>"language"</code> and <code>"value"</code>.
+               <li>In case of multiple localized options, ensure it is an array. Either all objects have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects have two fields <code>"language"</code> and <code>"value"</code>.
+            </ul>
+            <li>Confirm each field <code>"taal"</code> or <code>"language"</code> has a value in [[RFC5646]] format.
+         </ul>
+      </dd>
+   </dl>
+</div>
+
 ## Date and time
 
 Handling date and time is tricky and can lead to confusion among clients. The date-time rules remove ambiguity and provide clarity in the API contract between servers and clients.

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -215,61 +215,61 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
 </div>
 
 <div class="rule" id="/core/lang-code" data-type="technical">
-   <p class="rulelab">Use standard language codes for localization</p>
+   <p class="rulelab">Use standard language codes and field names for multilingual content</p>
    <dl>
       <dt>Statement</dt>
       <dd>
          <p>A resource containing localized information MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
-         All fields in requests and responses containing singular localized information MUST be an object with a field <code>"taal"</code> (Dutch) or <code>"language"</code> (English) with a value conforming [[RFC5646]] and a field <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) with the localized string.
+         All fields in requests and responses containing singular localized information MUST be an object with two fields (JSON) or tag with two subtags (XML). In it, <code>"taal"</code> (Dutch) or <code>"language"</code> (English) contains a value conforming [[RFC5646]] and <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) contains the localized string.
          <p class="note">Use the <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">language subtag registry</a> maintained by IANA for possible language subtags.
          <aside class="example">
-            The following example shows a response for a resource with singular localized information in an API with Dutch as its interface language.
+            The following example shows a response for a resource with singular localized information in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
-  "status": {
+  "ondertitel": {
     "taal": "nl-NL",
-    "waarde": "Goedgekeurd"
+    "waarde": "Een blogpost over API's"
   }
 }
 </code></pre>
          </aside>
          <aside class="example">
-            The following example shows a response for a resource with singular localized information in an API with English as its interface language.
+            The following example shows a response for a resource with singular localized information in an API with English as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
-  "status": {
+  "subtitle": {
     "language": "nl-NL",
-    "value": "Goedgekeurd"
+    "value": "Een blogpost over API's"
   }
 }
 </code></pre>
          </aside>
          <p>All fields in requests and responses containing multiple localized options MUST be an array of objects where all objects have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the localized string.
          <aside class="example">
-            The following example shows a response for a resource with multiple localized options in an API with Dutch as its interface language.
+            The following example shows a response for a resource with multiple localized options in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
-  "status": [
+  "ondertitel": [
      {
       "taal": "nl-NL",
-      "waarde": "Goedgekeurd"
+      "waarde": "Een blogpost over API's"
     },
     {
       "taal": "en-GB",
-      "waarde": "Accepted"
+      "waarde": "A blogpost about API's"
     }
   ]
 }
 </code></pre>
          </aside>
          <aside class="example">
-            The following example shows a response for a resource with multiple localized options in an API with English as its interface language.
+            The following example shows a response for a resource with multiple localized options in an API with English as its <a href="#/core/interface-language">interface language</a>.
             <pre><code class="json">{
-  "status": [
+  "subtitle": [
      {
       "language": "nl-NL",
-      "value": "Goedgekeurd"
+      "value": "Een blogpost over API's"
      },
      {
        "language": "en-GB",
-       "value": "Accepted"
+       "value": "A blogpost about API's"
      }
   ]
 }

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -220,61 +220,6 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
       <dt>Statement</dt>
       <dd>
          <p>A resource containing language content MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
-         All fields in requests and responses containing monolingual content MUST be an object with two fields (JSON) or tag with two subtags (XML). In it, <code>"taal"</code> (Dutch) or <code>"language"</code> (English) contains a value conforming [[RFC5646]] and <code>"waarde"</code> (Dutch) or <code>"value"</code> (English) contains the lingual content.
-         <p class="note">Use the <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">language subtag registry</a> maintained by IANA for possible language subtags.
-         <aside class="example">
-            The following example shows a response for a resource with monolingual content in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
-            <pre><code class="json">{
-  "ondertitel": {
-    "taal": "nl-NL",
-    "waarde": "Een blogpost over API's"
-  }
-}
-</code></pre>
-         </aside>
-         <aside class="example">
-            The following example shows a response for a resource with monolingual content in an API with English as its <a href="#/core/interface-language">interface language</a>.
-            <pre><code class="json">{
-  "subtitle": {
-    "language": "nl-NL",
-    "value": "Een blogpost over API's"
-  }
-}
-</code></pre>
-         </aside>
-         <p>All fields in requests and responses containing multilingual content MUST be an array of objects (JSON) or multiple children tags (XML). All elements either have a field <code>"taal"</code> (Dutch) or all have a field <code>"language"</code> (English) with a value conforming [[RFC5646]] and all have a field <code>"waarde"</code> (Dutch) or have a field <code>"value"</code> (English) with the lingual content.
-         <aside class="example">
-            The following example shows a response for a resource with multilingual content in an API with Dutch as its <a href="#/core/interface-language">interface language</a>.
-            <pre><code class="json">{
-  "ondertitel": [
-     {
-      "taal": "nl-NL",
-      "waarde": "Een blogpost over API's"
-    },
-    {
-      "taal": "en-GB",
-      "waarde": "A blogpost about API's"
-    }
-  ]
-}
-</code></pre>
-         </aside>
-         <aside class="example">
-            The following example shows a response for a resource with multilingual content in an API with English as its <a href="#/core/interface-language">interface language</a>.
-            <pre><code class="json">{
-  "subtitle": [
-     {
-      "language": "nl-NL",
-      "value": "Een blogpost over API's"
-     },
-     {
-       "language": "en-GB",
-       "value": "A blogpost about API's"
-     }
-  ]
-}
-</code></pre>
-         </aside>
          <p class="warning">[[?ISO3166-1]] concerns identifiers of countries and MUST NOT be used to denote languages, since countries and languages are not equivalent.
          <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format matches a language tag in [[RFC5646]] regardless of language subtag.
       </dd>
@@ -284,14 +229,7 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
       </dd>
       <dt>How to test</dt>
       <dd>
-         <ul>
-            <li>Analyse all fields and if the field represents a language and ensure either one of the following options applies:
-            <ul>
-               <li>In case of monolingual content, ensure it is an object (JSON) or tag (XML). It has two fields <code>"taal"</code> and <code>"waarde"</code> or it has two fields <code>"language"</code> and <code>"value"</code>.
-               <li>In case of multilingual content, ensure it is an array consisting of objects (JSON) or multiple children tags (XML). Either all objects/children have two fields <code>"taal"</code> and <code>"waarde"</code> or all objects/children have two fields <code>"language"</code> and <code>"value"</code>.
-            </ul>
-            <li>Confirm each field <code>"taal"</code> or <code>"language"</code> has a value in [[RFC5646]] format.
-         </ul>
+         Confirm each field that represents a language has a value in [[RFC5646]] format.
       </dd>
    </dl>
 </div>

--- a/sections/designRules.md
+++ b/sections/designRules.md
@@ -221,11 +221,11 @@ https://api.example.org/v1/vergunningen/d285e05c-6b01-45c3-92d8-5e19a946b66f</pr
       <dd>
          <p>A resource containing language content MUST follow <a href="https://www.rfc-editor.org/info/bcp47">BCP 47</a> [[RFC4647]] [[RFC5646]].
          <p class="warning">[[?ISO3166-1]] concerns identifiers of countries and MUST NOT be used to denote languages, since countries and languages are not equivalent.
-         <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format matches a language tag in [[RFC5646]] regardless of language subtag.
+         <p class="note">Following [[RFC4647]] a language code in [[?ISO-639-1]] format matches a language tag in [[RFC5646]] format regardless of language subtag.
       </dd>
       <dt>Rationale</dt>
       <dd>
-         Standardized language codes removes ambiguity in language handling between systems, potentially present in separate regions with different (spoken) languages.
+         Standardised language codes removes ambiguity in language handling between systems, potentially present in separate regions with different (spoken) languages.
       </dd>
       <dt>How to test</dt>
       <dd>

--- a/standaard.dic
+++ b/standaard.dic
@@ -1,4 +1,4 @@
-32
+33
 Aanbeveling
 backend
 camelCase
@@ -25,6 +25,7 @@ SameSite
 Specref
 Strategie
 subresource
+subtag
 URIs
 voor
 WebDAV


### PR DESCRIPTION
Hiermee standaardiseren we het gebruik van talen,
welk formaat taal codes in geschreven moeten worden en welke structuur in een object moet worden gebruikt.

Fixes #308