### PR TITLE
Beheer: verwijder duplicate trailing slash regel

### DIFF
--- a/linter/testcases/paths-kebab-slashes/expected-output.txt
+++ b/linter/testcases/paths-kebab-slashes/expected-output.txt
@@ -1,6 +1,6 @@
 
 /testcases/paths-kebab-slashes/openapi.json
-  96:26  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./suffix-slash/
- 154:37  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./nested-slash/met-suffix/
+  96:26  error  nlgov:paths-no-trailing-slash  Leave off trailing slashes from URIs.  paths./suffix-slash/
+ 154:37  error  nlgov:paths-no-trailing-slash  Leave off trailing slashes from URIs.  paths./nested-slash/met-suffix/
 
 ✖ 2 problems (2 errors, 0 warnings, 0 infos, 0 hints)

--- a/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
+++ b/linter/testcases/paths-kebab-zoek-uitzondering/expected-output.txt
@@ -1,5 +1,5 @@
 
 /testcases/paths-kebab-zoek-uitzondering/openapi.json
- 125:19  error  path-keys-no-trailing-slash  Path must not end with slash.  paths./_zoek/
+ 125:19  error  nlgov:paths-no-trailing-slash  Leave off trailing slashes from URIs.  paths./_zoek/
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)

--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -95,7 +95,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        notMatch: ".+ \\/$"
+        notMatch: ".+\\/$"
       field: "@key"
     message: "Leave off trailing slashes from URIs."
     documentationUrl: "https://developer.overheid.nl/kennisbank/apis/api-design-rules/hoe-te-voldoen/no-trailing-slash"

--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -31,9 +31,6 @@ rules:
   oas3-server-variables: error
   oas3-api-servers: error
 
-  #/core/no-trailing-slash
-  path-keys-no-trailing-slash: error
-
   #/core/doc-openapi
   nlgov:openapi3:
     severity: error


### PR DESCRIPTION
We hebben hier al een eigen regel voor met extra documentatie naar developer.overheid.nl Dus de Spectral core regel hebben we niet nodig.