### PR TITLE
Beheer: zet alle relevante linter regels op error

### DIFF
--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -168,20 +168,8 @@ rules:
       functionOptions:
         match: ^\$?[a-z][a-z\d]*([A-Z][a-z\d]*)*$
 
-  nlgov:schema-camel-case:
-    severity: warn
-    message: "Schema name should be UpperCamelCase in {{path}}"
-    given: >-
-      $.components.schemas[*]~
-    then:
-      function: casing
-      functionOptions:
-        type: pascal
-        separator:
-          char: ""
-
   nlgov:servers-use-https:
-    severity: warn
+    severity: error
     message: "Server URL {{value}} {{error}}."
     given:
       - $.servers[*]
@@ -241,7 +229,7 @@ rules:
               - "400"
 
   nlgov:property-casing:
-    severity: warn
+    severity: error
     given:
       - "$.*.schemas[*].properties.[?(@property && @property.match(/_links/i))]"
     then:


### PR DESCRIPTION
Hiermee zijn er geen warnings meer. Dit maakt het mogelijk voor developer.overheid.nl om warnings te genereren voor toekomstige linter versies. Ze willen namelijk regels die nieuw zijn in versie 2.X toevoegen als warnings aan versie 2.(X - 1).