### PR TITLE
Beheer: haal property casing schema rule weg

### DIFF
--- a/media/linter.yaml
+++ b/media/linter.yaml
@@ -228,17 +228,6 @@ rules:
               required:
               - "400"
 
-  nlgov:property-casing:
-    severity: error
-    given:
-      - "$.*.schemas[*].properties.[?(@property && @property.match(/_links/i))]"
-    then:
-      function: casing
-      functionOptions:
-        type: camel
-      field: "@key"
-    message: Properties must be lowerCamelCase.
-
   #/core/date-time/timezone
   nlgov:date-time-ensure-timezone:
     severity: error


### PR DESCRIPTION
Er is een rule voor het gebruik van camelCase
van query keys: `nlgov:query-keys-camel-case`.
Ik ging er onterecht vanuit dat deze regel ook
hiervoor is.

Dat is echter niet zo, want deze regel gaat over
het beschrijven van schema's in een OpenAPI
specificatie. Dat is niet als regel in de ADR
opgenomen en moeten we daarom ook niet
checken.

Fixes #340